### PR TITLE
Delay TAG representation for faster rendering

### DIFF
--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -43,7 +43,7 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
 
   val vocabFile          = config[File]("odinson.compiler.dependenciesVocabulary")
 
-  val pageSize           = config[Int]("odinson.pageSize") // TODO move to config?
+  val pageSize           = config[Int]("odinson.pageSize")
 
   val extractorEngine = new ExtractorEngine(indexDir)
   val odinsonContext: ExecutionContext = system.dispatchers.lookup("contexts.odinson")

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ odinson {
   indexDir = ${odinson.dataDir}/index
 
   # how many search results to display per page
-  pageSize = 5
+  pageSize = 20
 
   state {
     jdbc {

--- a/ui/config.js
+++ b/ui/config.js
@@ -9,6 +9,9 @@ config.queryParams.label        = "label";
 config.queryParams.commit       = "commit";
 config.queryParams.prevDoc      = "prevDoc";
 config.queryParams.prevScore    = "prevScore";
+// to expand sentence to full info
+config.sentParams               = {};
+config.sentParams.sentId        = "sentId";
 // TAG settings for Odinson
 config.tag = {};
 config.tag.showTopArgLabels   = false;

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "react": "^16.5.2",
     "react-ace": "^6.4.0",
     "react-dom": "^16.5.2",
+    "react-html-parser": "^2.0.2",
     "react-router-dom": "^4.3.1",
     "react-select": "^2.4.1",
     "react-toastify": "^4.5.2",

--- a/ui/src/client/App.js
+++ b/ui/src/client/App.js
@@ -10,6 +10,6 @@ export default class App extends Component {
   }
 
   render() {
-    return (<OdinsonRoutes/>)
+    return <OdinsonRoutes />
   }
 }

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -24,6 +24,10 @@ mark {
   padding: 3px;
 }
 
+table.bp3-html-table td {
+  padding: 4px 7px;
+}
+
 /*
   The following styles correspond to className assignments
 */

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -63,7 +63,7 @@ body {
 }
 
 .sentenceResults {
-  width: 100%;
+  width: 1000px;
 }
 
 /*#root div{

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -6,6 +6,11 @@ h1 {
   color: green;
 }
 
+h2 {
+  margin: 0;
+  padding: 30px 0 0 0;
+}
+
 body {
   font-family: "Open Sans", sans-serif;
   text-align: center;
@@ -64,13 +69,12 @@ mark {
 }
 
 .pageNumbers {
-  display: flex;
-  flex-direction: row;
   align-self: center;
+  padding: 0 10px 0 10px;
 }
 
 .sentenceResults {
-  width: 1000px;
+  padding: 10px 0 0 0;
   align-self: center;
   align-items: center;
 }
@@ -78,3 +82,7 @@ mark {
 /*#root div{
   width:100%;
 }*/
+
+.parentDoc {
+  padding: 10px 0 20px 0;
+}

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -13,6 +13,7 @@ body {
 }
 
 mark {
+  font-weight: bold;
   color: white;
   background-color: green;
   padding: 3px;
@@ -70,6 +71,8 @@ mark {
 
 .sentenceResults {
   width: 1000px;
+  align-self: center;
+  align-items: center;
 }
 
 /*#root div{

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -27,7 +27,7 @@ mark {
 .searchFields {
   display: 'flex';
   flexDirection: 'column';
-  width: 1000px;
+  width: 800px;
   padding: 5px;
 }
 
@@ -73,7 +73,7 @@ mark {
   display: flex;
   flex-direction: row;
   height: 200px;
-  width: 1610px;
+  width: 800px;
   max-width: 1610px;
   align-self: center;
 }
@@ -90,7 +90,7 @@ mark {
 }
 
 .scoreDocs {
-  max-width: 1610px;
+  max-width: 800;
   align-self: center;
   align-items: center;
 }

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -24,8 +24,11 @@ mark {
   padding: 3px;
 }
 
-table.bp3-html-table td {
-  padding: 4px 7px;
+.searchFields {
+  display: 'flex';
+  flexDirection: 'column';
+  width: 1000px;
+  padding: 5px;
 }
 
 /*
@@ -70,6 +73,9 @@ table.bp3-html-table td {
   display: flex;
   flex-direction: row;
   height: 200px;
+  width: 1610px;
+  max-width: 1610px;
+  align-self: center;
 }
 
 .pageNumbers {
@@ -79,6 +85,12 @@ table.bp3-html-table td {
 
 .sentenceResults {
   padding: 10px 0 0 0;
+  align-self: center;
+  align-items: center;
+}
+
+.scoreDocs {
+  max-width: 1610px;
   align-self: center;
   align-items: center;
 }

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -12,6 +12,12 @@ body {
   margin: auto;
 }
 
+mark {
+  color: white;
+  background-color: green;
+  padding: 3px;
+}
+
 /*
   The following styles correspond to className assignments
 */

--- a/ui/src/client/app.css
+++ b/ui/src/client/app.css
@@ -7,6 +7,7 @@ h1 {
 }
 
 body {
+  font-family: "Open Sans", sans-serif;
   text-align: center;
   margin: auto;
 }
@@ -15,7 +16,7 @@ body {
   The following styles correspond to className assignments
 */
 .errorMsg {
-  font-family: monospace;
+  font-family: "Fira Mono", monospace;
   text-align: left;
   white-space: pre-wrap;
   color: red;
@@ -25,7 +26,7 @@ body {
   Display of executed queries in details table
 */
 .queryString {
-  font-family: monospace;
+  font-family: "Fira Mono", monospace;
   font-weight: bold;
   font-size: 1em;
 }
@@ -35,6 +36,15 @@ body {
   display: flex;
   flex-direction: column;
   /*flex-wrap: wrap;*/
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.row {
+  display: flex;
+  /*padding: 0 20px;*/
+  align-self: center;
   align-items: center;
   justify-content: center;
   width: 100%;
@@ -50,6 +60,10 @@ body {
   display: flex;
   flex-direction: row;
   align-self: center;
+}
+
+.sentenceResults {
+  width: 100%;
 }
 
 /*#root div{

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -221,6 +221,7 @@ export default class OdinsonUI extends Component {
           odinsonDocId={scoreDoc.odinsonDoc}
           odinsonJson={scoreDoc}
           key={`result-frame-${scoreDoc.odinsonDoc}`}
+          expanded={false}
           />;
       });
       return (

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -314,6 +314,7 @@ export default class OdinsonUI extends Component {
             pageEnds={this.state.pageEnds}
           />
           <ExpandToggle
+            hidden={this.state.results.totalHits === 0}
             expanded={this.state.expanded}
             handleExpand={this.handleExpand}
             handleCollapse={this.handleCollapse}
@@ -402,6 +403,10 @@ class ExpandToggle extends Component {
   }
 
   render() {
+    if(this.props.hidden) {
+      return null
+    }
+
     if(this.props.expanded) {
       return (
         <Tooltip content='Hide annotated view'>

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -212,7 +212,7 @@ export default class OdinsonUI extends Component {
       .groupBy(sd => sd.documentId)
       .mapValues(group => _(group).orderBy(elem => elem.sentenceIndex).value())
       .value();
-    //console.log(groupedResults);
+    console.log(groupedResults);
     const resultElements = Object.keys(groupedResults).map(parentDocId => {
       const scoreDocs = groupedResults[parentDocId];
       // console.log(scoreDocs);

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -180,13 +180,7 @@ export default class OdinsonUI extends Component {
             ':commit': ':commit <label>\n\tCommits the odinson results to the state using the provided label'
           }}
         />
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            width: '1000px'
-          }}
-          >
+        <div className='searchFields'>
           <InputGroup
             type='text'
             name='odinsonQuery'

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -304,7 +304,15 @@ export default class OdinsonUI extends Component {
             odinsonQuery={this.state.results.odinsonQuery}
             parentQuery={this.state.results.parentQuery}
           />
-          <hr />
+          <PageNavigation
+            handleHeadClick={this.handleHeadClick}
+            handleLeftClick={this.handleLeftClick}
+            handleRightClick={this.handleRightClick}
+            // handleLastClick={this.handleLastClick}
+            currentPage={this.state.currentPage}
+            totalPages={this.state.totalPages}
+            pageEnds={this.state.pageEnds}
+          />
           <ExpandToggle
             expanded={this.state.expanded}
             handleExpand={this.handleExpand}
@@ -337,6 +345,7 @@ export default class OdinsonUI extends Component {
   }
 }
 
+// a div containing a page's results in order
 class Results extends Component {
   constructor(props) {
     super(props);
@@ -372,7 +381,7 @@ class Results extends Component {
           />;
       });
       return (
-        <div key={`container-${parentDocId}`}>
+        <div className='parentDoc' key={`container-${parentDocId}`}>
           <h2>Parent Doc: {parentDocId}</h2>
           {scoreDocsGroup}
         </div>

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -9,8 +9,8 @@ import {
 } from "@blueprintjs/core";
 import './app.css';
 import "text-annotation-graphs/dist/tag/css/tag.css"
-import OdinsonTAG from './odinson-tag';
 
+import ResultFrame from './result-frame';
 import Terminal from 'terminal-in-react';
 import QueryDetails from './query-details';
 import PageNavigation from './page-navigation';
@@ -99,11 +99,11 @@ export default class OdinsonUI extends Component {
             results: response
           });
           if (newSearch) {
-            const tp = Math.ceil(response.totalHits / Math.max(response.scoreDocs.length, 1))
-            console.log("Total pages: " + tp)
+            const tp = Math.ceil(response.totalHits / Math.max(response.scoreDocs.length, 1));
+            console.log("Total pages: " + tp);
             this.setState({
               totalPages: tp
-            })
+            });
           }
         }
       });
@@ -209,19 +209,19 @@ export default class OdinsonUI extends Component {
     where values are sorted by their **order of appearance** in the document
     */
     const groupedResults = _(this.state.results.scoreDocs)
-    .groupBy(sd => sd.documentId)
-    .mapValues(group => _(group).orderBy(elem => elem.sentenceIndex).value())
-    .value();
+      .groupBy(sd => sd.documentId)
+      .mapValues(group => _(group).orderBy(elem => elem.sentenceIndex).value())
+      .value();
     //console.log(groupedResults);
     const resultElements = Object.keys(groupedResults).map(parentDocId => {
       const scoreDocs = groupedResults[parentDocId];
       // console.log(scoreDocs);
       const scoreDocsGroup = scoreDocs.map(scoreDoc => {
-        return <OdinsonTAG
+        return <ResultFrame
           odinsonDocId={scoreDoc.odinsonDoc}
           odinsonJson={scoreDoc}
-          key={`odinson-tag-${scoreDoc.odinsonDoc}`}
-          ></OdinsonTAG>;
+          key={`result-frame-${scoreDoc.odinsonDoc}`}
+          />;
       });
       return (
         <div key={`container-${parentDocId}`}>
@@ -334,15 +334,14 @@ export default class OdinsonUI extends Component {
             pageEnds={this.state.pageEnds}
           />
         </div>
-      )
-    } 
+      );
+    }
 
     return (
       <div>
         <ToastContainer/>
         {this.createSearchInterface()}
       </div>
-    )
-
+    );
   }
 }

--- a/ui/src/client/odinson-ui.js
+++ b/ui/src/client/odinson-ui.js
@@ -79,9 +79,9 @@ export default class OdinsonUI extends Component {
     // TODO: retrieve/build autocomplete
   }
 
-  runQuery(commit=false, label=null, newSearch=true) {
+  runQuery(commit=false, label=null, newSearch=true, rich=false) {
     if (this.state.odinsonQuery) {
-      console.log(`runQuery(${commit}, ${label}, ${newSearch})`);
+      // console.log(`runQuery(${commit}, ${label}, ${newSearch})`);
       this.resetResults();
       if (newSearch) {
         this.resetPages();
@@ -95,7 +95,8 @@ export default class OdinsonUI extends Component {
       }
       data[config.queryParams.commit]       = commit;
       data[config.queryParams.label]        = label;
-      axios.get('api/search', {
+      const searchRoute = rich ? 'api/rich-search' : 'api/search';
+      axios.get(searchRoute, {
         params: data,
       }).then(res => {
         const response = res.data;
@@ -155,7 +156,7 @@ export default class OdinsonUI extends Component {
           commands={{
             ':query': (args, print, runCommand) => {
               if (args.length == 1) {
-                this.runQuery();
+                this.runQuery(false, null, true, this.state.expanded);
                 print(`Running query...`);
               } else {
                 print(`ERROR: unrecognized command`);
@@ -163,12 +164,12 @@ export default class OdinsonUI extends Component {
             },
             ':commit': (args, print, runCommand) => {
               if (args.length == 1) {
-                this.runQuery(true);
+                this.runQuery(true, null, true, this.state.expanded);
                 print(`Running query and committing results...`);
               } else if (args.length == 2) {
                 const label = args[1];
                 console.log(`label: ${label}`);
-                this.runQuery(true, label);
+                this.runQuery(true, label, true, this.state.expanded);
                 print(`Running query and committing results as label '${label}'...`);
               } else {
                   print(`ERROR: unrecognized command`);
@@ -204,7 +205,7 @@ export default class OdinsonUI extends Component {
   // navigate to the first page (start query over again)
   handleHeadClick() {
     if (this.state.currentPage > 1) {
-      this.runQuery(false, null, true);
+      this.runQuery(false, null, true, this.state.expanded);
       console.log('Requesting first page');
       // console.log('After: ' + this.state.pageEnds);
     }
@@ -220,7 +221,7 @@ export default class OdinsonUI extends Component {
           currentPage: this.state.currentPage - 1
         },
         function () {
-          this.runQuery(false, null, false);
+          this.runQuery(false, null, false, this.state.expanded);
           console.log('Requesting previous page');
           // console.log('After: ' + this.state.pageEnds);
         }
@@ -240,7 +241,7 @@ export default class OdinsonUI extends Component {
         },
         function () {
           // console.log('After: ' + this.state.pageEnds);
-          this.runQuery(false, null, false);
+          this.runQuery(false, null, false, this.state.expanded);
           console.log('Requesting next page');
         }
       );
@@ -252,7 +253,7 @@ export default class OdinsonUI extends Component {
         },
         function () {
           // console.log('After: ' + this.state.pageEnds);
-          this.runQuery(false, null, false);
+          this.runQuery(false, null, false, this.state.expanded);
           console.log('Requesting next page');
         }
       );
@@ -264,7 +265,10 @@ export default class OdinsonUI extends Component {
   // }
 
   handleExpand() {
-    this.setState({'expanded': true});
+    this.setState(function() {
+      return ({'expanded': true});
+    });
+    this.runQuery(false, null, false, true);
   }
 
   handleCollapse() {

--- a/ui/src/client/page-navigation.js
+++ b/ui/src/client/page-navigation.js
@@ -24,16 +24,14 @@ export default class PageNavigation extends Component {
               icon="chevron-backward"
               disabled={this.props.currentPage === 1}
               onClick={this.props.handleHeadClick}
-            >
-            </Button>
+            />
           </Tooltip>
           <Tooltip content="Go to previous page" className={Classes.DARK}>
             <Button
               icon="chevron-left"
               disabled={this.props.currentPage === 1}
               onClick={this.props.handleLeftClick}
-            >
-            </Button>
+            />
           </Tooltip>
           <div className="pageNumbers">
             {this.props.currentPage} / {this.props.totalPages}
@@ -43,10 +41,9 @@ export default class PageNavigation extends Component {
               icon="chevron-right"
               disabled={this.props.currentPage == this.props.totalPages}
               onClick={this.props.handleRightClick}
-            >
-            </Button>
+            />
           </Tooltip>
-          <Button disabled={true}></Button>
+          <Button disabled={true}/>
           {/*<Tooltip content="Not implemented yet" className={Classes.DARK}>
             <Button
               icon="chevron-forward"

--- a/ui/src/client/page-navigation.js
+++ b/ui/src/client/page-navigation.js
@@ -4,7 +4,7 @@ import {
   Button,
   Classes,
   Tooltip
-} from "@blueprintjs/core";
+} from '@blueprintjs/core';
 
 export default class PageNavigation extends Component {
   constructor(props) {
@@ -16,37 +16,37 @@ export default class PageNavigation extends Component {
       return null
     }
     return (
-      <div className="navigation">
+      <div className='navigation'>
       <hr></hr>
         <ButtonGroup minimal={true} large={true}>
-          <Tooltip content="Go to first page">
+          <Tooltip content='Go to first page'>
             <Button
-              icon="chevron-backward"
+              icon='chevron-backward'
               disabled={this.props.currentPage === 1}
               onClick={this.props.handleHeadClick}
             />
           </Tooltip>
-          <Tooltip content="Go to previous page">
+          <Tooltip content='Go to previous page'>
             <Button
-              icon="chevron-left"
+              icon='chevron-left'
               disabled={this.props.currentPage === 1}
               onClick={this.props.handleLeftClick}
             />
           </Tooltip>
-          <div className="pageNumbers">
+          <div className='pageNumbers'>
             {this.props.currentPage} / {this.props.totalPages}
           </div>
-          <Tooltip content="Go to next page">
+          <Tooltip content='Go to next page'>
             <Button
-              icon="chevron-right"
+              icon='chevron-right'
               disabled={this.props.currentPage == this.props.totalPages}
               onClick={this.props.handleRightClick}
             />
           </Tooltip>
           <Button disabled={true}/>
-          {/*<Tooltip content="Not implemented yet" className={Classes.DARK}>
+          {/*<Tooltip content='Not implemented yet' className={Classes.DARK}>
             <Button
-              icon="chevron-forward"
+              icon='chevron-forward'
               //disabled={this.props.currentPage == this.props.totalPages}
               disabled={true}
               onClick={this.props.handleLastClick}

--- a/ui/src/client/page-navigation.js
+++ b/ui/src/client/page-navigation.js
@@ -19,14 +19,14 @@ export default class PageNavigation extends Component {
       <div className="navigation">
       <hr></hr>
         <ButtonGroup minimal={true} large={true}>
-          <Tooltip content="Go to first page" className={Classes.DARK}>
+          <Tooltip content="Go to first page">
             <Button
               icon="chevron-backward"
               disabled={this.props.currentPage === 1}
               onClick={this.props.handleHeadClick}
             />
           </Tooltip>
-          <Tooltip content="Go to previous page" className={Classes.DARK}>
+          <Tooltip content="Go to previous page">
             <Button
               icon="chevron-left"
               disabled={this.props.currentPage === 1}
@@ -36,7 +36,7 @@ export default class PageNavigation extends Component {
           <div className="pageNumbers">
             {this.props.currentPage} / {this.props.totalPages}
           </div>
-          <Tooltip content="Go to next page" className={Classes.DARK}>
+          <Tooltip content="Go to next page">
             <Button
               icon="chevron-right"
               disabled={this.props.currentPage == this.props.totalPages}

--- a/ui/src/client/query-details.js
+++ b/ui/src/client/query-details.js
@@ -15,7 +15,7 @@ export default class QueryDetails extends Component {
     const formattedHits = this.props.totalHits.toLocaleString();
     return (
       <div className="queryDetails">
-        <HTMLTable>
+        <HTMLTable condensed={true} striped={true}>
           <tbody>
             <tr>
               <td><strong>Odinson Query</strong></td>

--- a/ui/src/client/result-frame.js
+++ b/ui/src/client/result-frame.js
@@ -3,13 +3,13 @@ import ReactHtmlParser, { processNodes,
   convertNodeToElement, 
   htmlparser2 
 } from 'react-html-parser';
-import TAG from "text-annotation-graphs";
+import TAG from 'text-annotation-graphs';
 import {
   ButtonGroup,
   Button,
   Classes,
   Tooltip
-} from "@blueprintjs/core";
+} from '@blueprintjs/core';
 import PropTypes from 'prop-types';
 
 const config = require('../../config');
@@ -18,21 +18,25 @@ export default class ResultFrame extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      'expanded': props.expanded
+      expanded: props.expanded
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ expanded: nextProps.expanded });
   }
 
   render() {
     if(this.state.expanded) {
       return (
-        <div className="sentenceResults">
-          <div className="row">
-            <Tooltip content="See less detail">
+        <div className='sentenceResults'>
+          <div className='row'>
+            <Tooltip content='See less detail'>
               <Button
-                icon="collapse-all"
+                icon='collapse-all'
                 minimal={true}
                 large={true}
-                onClick={() => this.setState({'expanded': false})}
+                onClick={() => this.setState({expanded: false})}
               />
             </Tooltip>
             <h3>Sentence ID: {this.props.odinsonDocId}</h3>
@@ -44,14 +48,14 @@ export default class ResultFrame extends Component {
       )
     } else {
       return (
-        <div className="sentenceResults">
-          <div className="row">
-            <Tooltip content="See more detail">
+        <div className='sentenceResults'>
+          <div className='row'>
+            <Tooltip content='See more detail'>
               <Button
-                icon="expand-all"
+                icon='expand-all'
                 minimal={true}
                 large={true}
-                onClick={() => this.setState({'expanded': true})}
+                onClick={() => this.setState({expanded: true})}
               />
             </Tooltip>
             <h3>Sentence ID: {this.props.odinsonDocId}</h3>
@@ -100,7 +104,7 @@ class OdinsonHighlight extends Component {
 
   render() {
     return (
-      <div className="highlights">
+      <div className='highlights'>
         {this.state.displayText}
       </div>
     )
@@ -122,7 +126,7 @@ class OdinsonTAG extends Component {
     const odinsonTAG = TAG.tag({
       container: this.tagRef.current,
       data: this.props.odinsonJson,
-      format: "odinson",
+      format: 'odinson',
       // Overrides for default options
       options: {
         showTopArgLabels: config.tag.showTopArgLabels,
@@ -142,7 +146,7 @@ class OdinsonTAG extends Component {
 
     return (
       // TODO: add div and dropdown button allowing one to reconfigure TAG elements
-      <div ref={this.tagRef} className="scoreDoc"></div>
+      <div ref={this.tagRef} className='scoreDoc'></div>
     )
   }
 }

--- a/ui/src/client/result-frame.js
+++ b/ui/src/client/result-frame.js
@@ -1,0 +1,129 @@
+import React, { Component } from 'react';
+import TAG from "text-annotation-graphs";
+import {
+  ButtonGroup,
+  Button,
+  Classes,
+  Tooltip
+} from "@blueprintjs/core";
+
+const config = require('../../config');
+
+export default class ResultFrame extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      'expanded': props.expanded
+    };
+    
+    this.handleExpand = this.handleExpand.bind(this);
+    this.handleCollapse = this.handleCollapse.bind(this);
+  }
+
+  handleExpand () {
+    this.setState({
+      'expanded': true
+    });
+  }
+
+  handleCollapse () {
+    this.setState({
+      'expanded': false
+    });
+  }
+
+  render() {
+    if(this.state.expanded) {
+      return (
+        <div className="sentenceResults">
+          <div className="row">
+            <Tooltip content="See less detail" className={Classes.DARK}>
+              <Button
+                icon="collapse-all"
+                minimal={true}
+                large={true}
+                onClick={() => this.setState({'expanded': false})}
+              />
+            </Tooltip>
+            <h3>Sentence ID: {this.props.odinsonDocId}</h3>
+          </div>
+          <OdinsonTAG
+            odinsonDocId={this.props.odinsonDocId}
+            odinsonJson={this.props.odinsonJson}
+          />
+        </div>
+      )
+    } else {
+      return (
+        <div className="sentenceResults">
+          <div className="row">
+            <Tooltip content="See more detail" className={Classes.DARK}>
+              <Button
+                icon="expand-all"
+                minimal={true}
+                large={true}
+                onClick={() => this.setState({'expanded': true})}
+              />
+            </Tooltip>
+            <h3>Sentence ID: {this.props.odinsonDocId}</h3>
+          </div>
+          <OdinsonHighlight
+            odinsonDocId={this.props.odinsonDocId}
+            odinsonJson={this.props.odinsonJson}
+          />
+        </div>
+      )
+    }
+  }
+}
+
+class OdinsonHighlight extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="highlights">
+        {this.props.odinsonJson.sentence.words.join(" ")}
+      </div>
+    )
+  }
+}
+
+class OdinsonTAG extends Component {
+  constructor(props) {
+    super(props);
+    this.tagRef      = React.createRef();
+    this.tagInstance = null;
+  }
+
+  componentDidMount() {
+    const odinsonTAG = TAG.tag({
+      container: this.tagRef.current,
+      data: this.props.odinsonJson,
+      format: "odinson",
+      // Overrides for default options
+      options: {
+        showTopArgLabels: config.tag.showTopArgLabels,
+        bottomLinkCategory: config.tag.bottomLinkCategory,
+        linkSlotInterval: config.tag.linkSlotInterval,
+        compactRows: config.tag.compactRows
+      }
+    });
+    this.tagInstance = odinsonTAG;
+  }
+
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+
+    return (
+      // TODO: add div and dropdown button allowing one to reconfigure TAG elements
+      <div ref={this.tagRef} className="scoreDoc"></div>
+    )
+  }
+}
+

--- a/ui/src/client/result-frame.js
+++ b/ui/src/client/result-frame.js
@@ -86,7 +86,7 @@ class OdinsonHighlight extends Component {
   }
 
   makeHighlights() {
-    var base = this.props.odinsonJson.sentence.words;
+    var base = this.props.odinsonJson.sentence.words.slice();
     var matches = this.props.odinsonJson.matches;
     matches.forEach(function (m) {
       const start = m.span.start;

--- a/ui/src/client/result-frame.js
+++ b/ui/src/client/result-frame.js
@@ -6,6 +6,7 @@ import {
   Classes,
   Tooltip
 } from "@blueprintjs/core";
+import PropTypes from 'prop-types';
 
 const config = require('../../config');
 
@@ -15,21 +16,6 @@ export default class ResultFrame extends Component {
     this.state = {
       'expanded': props.expanded
     };
-    
-    this.handleExpand = this.handleExpand.bind(this);
-    this.handleCollapse = this.handleCollapse.bind(this);
-  }
-
-  handleExpand () {
-    this.setState({
-      'expanded': true
-    });
-  }
-
-  handleCollapse () {
-    this.setState({
-      'expanded': false
-    });
   }
 
   render() {
@@ -37,7 +23,7 @@ export default class ResultFrame extends Component {
       return (
         <div className="sentenceResults">
           <div className="row">
-            <Tooltip content="See less detail" className={Classes.DARK}>
+            <Tooltip content="See less detail">
               <Button
                 icon="collapse-all"
                 minimal={true}
@@ -57,7 +43,7 @@ export default class ResultFrame extends Component {
       return (
         <div className="sentenceResults">
           <div className="row">
-            <Tooltip content="See more detail" className={Classes.DARK}>
+            <Tooltip content="See more detail">
               <Button
                 icon="expand-all"
                 minimal={true}
@@ -75,6 +61,10 @@ export default class ResultFrame extends Component {
       )
     }
   }
+}
+
+ResultFrame.propTypes = {
+  expanded: PropTypes.bool.isRequired
 }
 
 class OdinsonHighlight extends Component {

--- a/ui/src/client/result-frame.js
+++ b/ui/src/client/result-frame.js
@@ -1,4 +1,8 @@
 import React, { Component } from 'react';
+import ReactHtmlParser, { processNodes, 
+  convertNodeToElement, 
+  htmlparser2 
+} from 'react-html-parser';
 import TAG from "text-annotation-graphs";
 import {
   ButtonGroup,
@@ -34,7 +38,6 @@ export default class ResultFrame extends Component {
             <h3>Sentence ID: {this.props.odinsonDocId}</h3>
           </div>
           <OdinsonTAG
-            odinsonDocId={this.props.odinsonDocId}
             odinsonJson={this.props.odinsonJson}
           />
         </div>
@@ -54,7 +57,6 @@ export default class ResultFrame extends Component {
             <h3>Sentence ID: {this.props.odinsonDocId}</h3>
           </div>
           <OdinsonHighlight
-            odinsonDocId={this.props.odinsonDocId}
             odinsonJson={this.props.odinsonJson}
           />
         </div>
@@ -64,21 +66,49 @@ export default class ResultFrame extends Component {
 }
 
 ResultFrame.propTypes = {
-  expanded: PropTypes.bool.isRequired
+  expanded: PropTypes.bool.isRequired,
+  odinsonDocId: PropTypes.number.isRequired,
+  odinsonJson: PropTypes.object.isRequired
 }
 
 class OdinsonHighlight extends Component {
   constructor(props) {
     super(props);
+    this.state = {}
+
+    this.makeHighlights = this.makeHighlights.bind(this);
+  }
+
+  componentDidMount() {
+    this.setState({
+      displayText: this.makeHighlights()
+    })
+  }
+
+  makeHighlights() {
+    var base = this.props.odinsonJson.sentence.words;
+    var matches = this.props.odinsonJson.matches;
+    matches.forEach(function (m) {
+      const start = m.span.start;
+      const end = m.span.end;
+      base[start] = '<mark>' + base[start];
+      base[end - 1] = base[end - 1] + '</mark>';
+    })
+    const displayText = base.join(' ');
+    return <div>{ ReactHtmlParser(displayText) }</div>;
   }
 
   render() {
     return (
       <div className="highlights">
-        {this.props.odinsonJson.sentence.words.join(" ")}
+        {this.state.displayText}
       </div>
     )
   }
+}
+
+OdinsonHighlight.propTypes = {
+  odinsonJson: PropTypes.object.isRequired
 }
 
 class OdinsonTAG extends Component {
@@ -117,3 +147,6 @@ class OdinsonTAG extends Component {
   }
 }
 
+OdinsonTAG.propTypes = {
+  odinsonJson: PropTypes.object.isRequired
+}

--- a/ui/src/server/index.js
+++ b/ui/src/server/index.js
@@ -12,7 +12,69 @@ const config = require('../../config');
 app.use(cors());
 app.use(express.static('dist'));
 
+app.get('/api/sentence', (req, res) => {
+  const data = {};
+  data[config.sentParams.sentId] = req.query[config.sentParams.sentId];
+  console.log(data);
+  axios.get(`${config.odinsonApiBaseUrl}/sentence`, {
+    headers: {'Access-Control-Allow-Origin': '*'},
+    params: data,
+    responseType: 'json'
+  }).then(results => {
+    res.json(results.data)
+  }).catch(error => {
+    res.json(error.response.data)
+  });
+});
+
 app.get('/api/search', (req, res) => {
+  const data = {};
+  // handle odinson query
+  data[config.queryParams.odinsonQuery] = req.query[config.queryParams.odinsonQuery];
+  // handle parent query
+  const pq = req.query[config.queryParams.parentQuery];
+  if (pq) {
+    data[config.queryParams.parentQuery]   = pq;
+    console.log(`parentQuery: ${pq}`);
+  }
+  // handle page
+  const prevDoc = req.query[config.queryParams.prevDoc];
+  if (prevDoc) {
+    data[config.queryParams.prevDoc] = prevDoc;
+    console.log(`prevDoc: ${prevDoc}`);
+  }
+  const prevScore = req.query[config.queryParams.prevScore];
+  if (prevScore) {
+    data[config.queryParams.prevScore] = prevScore;
+    console.log(`prevScore: ${prevScore}`);
+  }
+  // handle commit
+  const commit = req.query[config.queryParams.commit];
+  if (commit === true || commit === "true") {
+    data[config.queryParams.commit]   = true;
+    console.log(`commit: ${commit}`);
+  }
+  // handle label
+  const label = req.query[config.queryParams.label];
+  if (label) {
+    data[config.queryParams.label]   = label;
+    console.log(`label: ${label}`);
+  }
+  console.log(data);
+  axios.get(`${config.odinsonApiBaseUrl}/search`, {
+    headers: {'Access-Control-Allow-Origin': '*'},
+    params: data,
+    responseType: 'json'
+  }).then(results => {
+    //console.log(results.data);
+    res.json(results.data)
+  }).catch(error => {
+    //console.log(error.response)
+    res.json(error.response.data)
+  });
+});
+
+app.get('/api/rich-search', (req, res) => {
   const data = {};
   // handle odinson query
   data[config.queryParams.odinsonQuery] = req.query[config.queryParams.odinsonQuery];


### PR DESCRIPTION
Provides functionality for presenting just plain text results (with elementary highlighting for matches) by default, greatly speeding initial rendering for the search results. Each sentence has its own `expand/collapse` button, and the page has an `expand/collapse all` button as well.

Limitations:
* Once collapsed, the TAG render is lost, so it takes just as long to render a second time.
* The parent object containing the `expand/collapse all` button does not track whether the individual sentences are expanded or not, so it is possible to have all sentences collapsed with the overall button still reading `Collapse all`.