### PR TITLE
Support for in-memory index

### DIFF
--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import javax.inject._
 import java.io.File
+
 import scala.util.control.NonFatal
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
@@ -15,7 +16,8 @@ import ai.lum.common.ConfigUtils._
 import ai.lum.common.FileUtils._
 import ai.lum.odinson.BuildInfo
 import ai.lum.odinson.ExtractorEngine
-import ai.lum.odinson.lucene.search.{ OdinsonScoreDoc }
+import ai.lum.odinson.digraph.Vocabulary
+import ai.lum.odinson.lucene.search.OdinsonScoreDoc
 import ai.lum.odinson.extra.DocUtils
 import ai.lum.odinson.lucene._
 import ai.lum.odinson.lucene.analysis.TokenStreamUtils
@@ -31,7 +33,7 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
   val docIdField         = config[String]("odinson.index.documentIdField")
   val sentenceIdField    = config[String]("odinson.index.sentenceIdField")
   val wordTokenField     = config[String]("odinson.index.wordTokenField")
-  val vocabFile          = config[File]("odinson.compiler.dependenciesVocabulary")
+  val vocabFile          = new File(config[File]("odinson.indexDir"), Vocabulary.FILE_NAME)
   val pageSize           = config[Int]("odinson.pageSize")
 
   val extractorEngine = ExtractorEngine.fromConfig("odinson")

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -33,7 +33,6 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
   val docIdField         = config[String]("odinson.index.documentIdField")
   val sentenceIdField    = config[String]("odinson.index.sentenceIdField")
   val wordTokenField     = config[String]("odinson.index.wordTokenField")
-  val vocabFile          = new File(config[File]("odinson.indexDir"), Vocabulary.FILE_NAME)
   val pageSize           = config[Int]("odinson.pageSize")
 
   val extractorEngine = ExtractorEngine.fromConfig("odinson")
@@ -69,14 +68,9 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
     */
   def dependenciesVocabulary(pretty: Option[Boolean]) = Action.async {
     Future {
-      val vocab: List[String] = {
-        vocabFile
-          .readString()
-          .lines
-          //.flatMap(dep => Seq(s">$dep", s"<$dep"))
-          .toList
-          .sorted
-      }
+      // NOTE: It's possible the vocabulary could change if the index is updated
+      val vocabulary = Vocabulary.fromIndex(config[File]("odinson.indexDir"))
+      val vocab = vocabulary.terms.toList.sorted
       val json  = Json.toJson(vocab)
       pretty match {
         case Some(true) => Ok(Json.prettyPrint(json))

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -47,8 +47,6 @@ odinson {
 
     outgoingTokenField = ${odinson.index.outgoingTokenField}
 
-    dependenciesVocabulary = ${odinson.index.dependenciesVocabulary}
-
     # if we are using the normalizedTokenField as the default
     # then we should normalize the queries to the default field
     # so that they match
@@ -80,8 +78,6 @@ odinson {
     outgoingTokenField = outgoing
 
     dependenciesField = dependencies
-
-    dependenciesVocabulary = ${odinson.indexDir}/dependenciesVocabulary.txt
 
     documentIdField = docId
 

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -160,7 +160,7 @@ object ExtractorEngine {
     val indexDir = config[Path]("indexDir")
     val indexReader = DirectoryReader.open(FSDirectory.open(indexDir))
     val indexSearcher = new OdinsonIndexSearcher(indexReader)
-    val compiler = QueryCompiler.fromConfig(config[Config]("compiler"))
+    val compiler = QueryCompiler.fromConfig(config)
     val jdbcUrl = config[String]("state.jdbc.url")
     val state = new State(jdbcUrl)
     state.init()

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -3,31 +3,27 @@ package ai.lum.odinson
 import java.io.File
 import java.nio.file.Path
 import java.util.Collection
+
 import scala.collection.JavaConverters._
 import org.apache.lucene.document.Document
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
-import org.apache.lucene.index.{ IndexWriter, IndexWriterConfig }
+import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
 import org.apache.lucene.index.IndexWriterConfig.OpenMode
-import org.apache.lucene.store.FSDirectory
-import ai.lum.odinson.digraph.{ DirectedGraph, Vocabulary }
+import org.apache.lucene.store.{Directory, FSDirectory, RAMDirectory}
+import ai.lum.common.ConfigUtils._
+import ai.lum.odinson.digraph.{DirectedGraph, Vocabulary}
+import ai.lum.odinson.utils.ConfigFactory
+import com.typesafe.config.Config
 
 class OdinsonIndexWriter(
-  val indexDir: Path,
-  val vocabularyFile: File
+  val directory: Directory,
+  val vocabulary: Vocabulary
 ) {
 
-  def this(indexDir: File, vocabularyFile: File) = {
-    this(indexDir.toPath, vocabularyFile)
-  }
-
-  // dependencies vocabulary
-  val vocabulary = Vocabulary.empty
-
-  val dir = FSDirectory.open(indexDir)
   val analyzer = new WhitespaceAnalyzer()
   val writerConfig = new IndexWriterConfig(analyzer)
   writerConfig.setOpenMode(OpenMode.CREATE)
-  val writer = new IndexWriter(dir, writerConfig)
+  val writer = new IndexWriter(directory, writerConfig)
 
   def addDocuments(block: Seq[Document]): Unit = {
     addDocuments(block.asJava)
@@ -37,8 +33,12 @@ class OdinsonIndexWriter(
     writer.addDocuments(block)
   }
 
-  def close(): Unit = {
-    vocabulary.dumpToFile(vocabularyFile)
+  def commit(): Unit = {
+    writer.commit()
+  }
+
+  def close(file: File): Unit = {
+    vocabulary.dumpToFile(file)
     writer.close()
   }
 
@@ -57,4 +57,34 @@ class OdinsonIndexWriter(
     DirectedGraph(incoming, outgoing, roots)
   }
 
+}
+
+
+object OdinsonIndexWriter {
+
+  def apply(directory: Directory, vocabulary: Vocabulary): OdinsonIndexWriter = new OdinsonIndexWriter(directory, vocabulary)
+
+  def apply(indexDir: File, vocabularyFile: File): OdinsonIndexWriter = {
+    val dir = FSDirectory.open(indexDir.toPath)
+    // dependencies vocabulary
+    val vocabulary = Vocabulary.empty
+    OdinsonIndexWriter(dir, vocabulary)
+  }
+
+  def apply(config: Config): OdinsonIndexWriter = {
+    val indexDir   = config[Path]("indexDir")
+    val directory  = FSDirectory.open(indexDir)
+    val vocabFile  = config[File]("odinson.compiler.dependenciesVocabulary")
+    val vocabulary = if (vocabFile.exists) {
+      Vocabulary.load(vocabFile)
+    } else Vocabulary.empty
+    OdinsonIndexWriter(directory, vocabulary)
+  }
+
+  def fromConfig: OdinsonIndexWriter = {
+    val config     = ConfigFactory.load()
+    OdinsonIndexWriter(config)
+  }
+
+  def inMemory: OdinsonIndexWriter = OdinsonIndexWriter(new RAMDirectory(), Vocabulary.empty)
 }

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -37,7 +37,7 @@ class OdinsonIndexWriter(
 
   def close(): Unit = {
     // FIXME: is this the correct instantiation of IOContext?
-    val stream = directory.createOutput(Vocabulary.FILE_NAME, new IOContext())
+    val stream = directory.createOutput(Vocabulary.FILE_NAME, new IOContext)
     stream.writeString(vocabulary.dump)
     stream.close()
     writer.close()
@@ -66,22 +66,16 @@ object OdinsonIndexWriter {
   def apply(directory: Directory, vocabulary: Vocabulary): OdinsonIndexWriter = new OdinsonIndexWriter(directory, vocabulary)
 
   def apply(indexDir: File): OdinsonIndexWriter = {
-    val dir = FSDirectory.open(indexDir.toPath)
+    val directory  = FSDirectory.open(indexDir.toPath)
     // dependencies vocabulary
-    val vocabFile  = new File (indexDir, Vocabulary.FILE_NAME)
-    val vocabulary = if (vocabFile.exists) {
-      Vocabulary.load(vocabFile)
-    } else Vocabulary.empty
-    OdinsonIndexWriter(dir, vocabulary)
+    val vocabulary = Vocabulary.fromIndex(directory)
+    OdinsonIndexWriter(directory, vocabulary)
   }
 
   def apply(config: Config): OdinsonIndexWriter = {
     val indexDir   = config[Path]("indexDir")
     val directory  = FSDirectory.open(indexDir)
-    val vocabFile  = new File (indexDir.toFile, Vocabulary.FILE_NAME)
-    val vocabulary = if (vocabFile.exists) {
-      Vocabulary.load(vocabFile)
-    } else Vocabulary.empty
+    val vocabulary = Vocabulary.fromIndex(directory)
     OdinsonIndexWriter(directory, vocabulary)
   }
 

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -9,7 +9,7 @@ import org.apache.lucene.document.Document
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
 import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
 import org.apache.lucene.index.IndexWriterConfig.OpenMode
-import org.apache.lucene.store.{Directory, FSDirectory, RAMDirectory}
+import org.apache.lucene.store.{Directory, FSDirectory, IOContext, RAMDirectory}
 import ai.lum.common.ConfigUtils._
 import ai.lum.odinson.digraph.{DirectedGraph, Vocabulary}
 import ai.lum.odinson.utils.ConfigFactory
@@ -33,12 +33,13 @@ class OdinsonIndexWriter(
     writer.addDocuments(block)
   }
 
-  def commit(): Unit = {
-    writer.commit()
-  }
+  def commit(): Unit = writer.commit()
 
-  def close(file: File): Unit = {
-    vocabulary.dumpToFile(file)
+  def close(): Unit = {
+    // FIXME: is this the correct instantiation of IOContext?
+    val stream = directory.createOutput(Vocabulary.FILE_NAME, new IOContext())
+    stream.writeString(vocabulary.dump)
+    stream.close()
     writer.close()
   }
 
@@ -64,17 +65,20 @@ object OdinsonIndexWriter {
 
   def apply(directory: Directory, vocabulary: Vocabulary): OdinsonIndexWriter = new OdinsonIndexWriter(directory, vocabulary)
 
-  def apply(indexDir: File, vocabularyFile: File): OdinsonIndexWriter = {
+  def apply(indexDir: File): OdinsonIndexWriter = {
     val dir = FSDirectory.open(indexDir.toPath)
     // dependencies vocabulary
-    val vocabulary = Vocabulary.empty
+    val vocabFile  = new File (indexDir, Vocabulary.FILE_NAME)
+    val vocabulary = if (vocabFile.exists) {
+      Vocabulary.load(vocabFile)
+    } else Vocabulary.empty
     OdinsonIndexWriter(dir, vocabulary)
   }
 
   def apply(config: Config): OdinsonIndexWriter = {
     val indexDir   = config[Path]("indexDir")
     val directory  = FSDirectory.open(indexDir)
-    val vocabFile  = config[File]("odinson.compiler.dependenciesVocabulary")
+    val vocabFile  = new File (indexDir.toFile, Vocabulary.FILE_NAME)
     val vocabulary = if (vocabFile.exists) {
       Vocabulary.load(vocabFile)
     } else Vocabulary.empty

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -427,7 +427,7 @@ object QueryCompiler {
       config[String]("dependenciesField"),
       config[String]("incomingTokenField"),
       config[String]("outgoingTokenField"),
-      Vocabulary.fromFile(config[File]("dependenciesVocabulary")),
+      Vocabulary.load(config[File]("dependenciesVocabulary")),
       config[Boolean]("normalizeQueriesToDefaultField")
     )
   }

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -422,7 +422,7 @@ object QueryCompiler {
       config[String]("compiler.dependenciesField"),
       config[String]("compiler.incomingTokenField"),
       config[String]("compiler.outgoingTokenField"),
-      Vocabulary.load(new File(config[File]("indexDir"), Vocabulary.FILE_NAME)),
+      Vocabulary.fromIndex(config[File]("indexDir")),
       config[Boolean]("compiler.normalizeQueriesToDefaultField")
     )
   }

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -414,21 +414,16 @@ class QueryCompiler(
 
 object QueryCompiler {
 
-  def fromConfig(path: String): QueryCompiler = {
-    val config = ConfigFactory.load()
-    fromConfig(config[Config](path))
-  }
-
   def fromConfig(config: Config): QueryCompiler = {
     new QueryCompiler(
-      config[List[String]]("allTokenFields"),
-      config[String]("defaultTokenField"),
-      config[String]("sentenceLengthField"),
-      config[String]("dependenciesField"),
-      config[String]("incomingTokenField"),
-      config[String]("outgoingTokenField"),
-      Vocabulary.load(config[File]("dependenciesVocabulary")),
-      config[Boolean]("normalizeQueriesToDefaultField")
+      config[List[String]]("compiler.allTokenFields"),
+      config[String]("compiler.defaultTokenField"),
+      config[String]("compiler.sentenceLengthField"),
+      config[String]("compiler.dependenciesField"),
+      config[String]("compiler.incomingTokenField"),
+      config[String]("compiler.outgoingTokenField"),
+      Vocabulary.load(new File(config[File]("indexDir"), Vocabulary.FILE_NAME)),
+      config[Boolean]("compiler.normalizeQueriesToDefaultField")
     )
   }
 

--- a/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
+++ b/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
@@ -64,7 +64,7 @@ object Vocabulary {
     new Vocabulary(buffer, map)
   }
 
-  def fromFile(file: File): Vocabulary = {
+  def load(file: File): Vocabulary = {
     load(file.readString(UTF_8))
   }
 

--- a/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
+++ b/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
@@ -1,9 +1,11 @@
 package ai.lum.odinson.digraph
 
-import java.io.File
+import java.io.{ File, IOException }
 import java.nio.charset.StandardCharsets.UTF_8
+
 import scala.collection.mutable
 import ai.lum.common.FileUtils._
+import org.apache.lucene.store.{ Directory, IOContext }
 
 /** This vocabulary is meant for the labels of the edges of the dependency graph.
  *  This object maps a term_id (int) to a symbol (string).
@@ -38,6 +40,8 @@ class Vocabulary(
     }
   }
 
+  def terms = idToTerm.toVector
+
   def dump: String = {
     idToTerm.mkString(Vocabulary.sep)
   }
@@ -68,6 +72,21 @@ object Vocabulary {
 
   def load(file: File): Vocabulary = {
     load(file.readString(UTF_8))
+  }
+
+  def fromIndex(directory: Directory): Vocabulary = try {
+    // FIXME: is this the correct instantiation of IOContext?
+    val stream = directory.openInput(Vocabulary.FILE_NAME, new IOContext)
+    Vocabulary.load(stream.readString())
+  } catch {
+    case e:IOException => Vocabulary.empty
+  }
+
+  def fromIndex(directory: File): Vocabulary = {
+    val vocabFile = new File(directory, Vocabulary.FILE_NAME)
+    if (vocabFile.exists) {
+      Vocabulary.load(vocabFile)
+    } else Vocabulary.empty
   }
 
 }

--- a/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
+++ b/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
@@ -52,6 +52,8 @@ object Vocabulary {
 
   val sep = "\n"
 
+  val FILE_NAME = "dependencies.txt"
+
   def empty: Vocabulary = {
     new Vocabulary(mutable.ArrayBuffer.empty, mutable.HashMap.empty)
   }

--- a/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
@@ -1,0 +1,184 @@
+package ai.lum.odinson
+
+import org.scalatest._
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import ai.lum.odinson.compiler.QueryCompiler
+import ai.lum.odinson.lucene._
+import ai.lum.odinson.lucene.analysis.{ NormalizedTokenStream, OdinsonTokenStream, TokenStreamUtils }
+import ai.lum.odinson.lucene.search._
+import ai.lum.odinson.state.State
+import ai.lum.odinson.utils.ConfigFactory
+import ai.lum.common.ConfigUtils._
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer
+import org.apache.lucene.search.highlight.TokenSources
+import org.apache.lucene.document.{ Document => LuceneDocument, _ }
+import org.apache.lucene.document.Field.Store
+import org.apache.lucene.index.DirectoryReader
+
+
+class TestPatterns extends FlatSpec with Matchers {
+
+  "patterns" should "match" in {
+    val patterns = Table(
+      ("pattern", "string", "expected"),
+      ("a b c", "a b c", "a b c"),
+      ("a b* c", "a b c", "a b c"),
+      ("a b* c", "a b b c", "a b b c"),
+      ("a b* c", "a c", "a c"),
+      ("a b* b c", "a b c", "a b c"),
+      ("a b* b c", "a b b c", "a b b c"),
+      ("a b* b c", "a b b b c", "a b b b c"),
+      ("a b* b c", "a b b b b c", "a b b b b c"),
+      ("a b+ c", "a b c", "a b c"),
+      ("a b+ c", "a b b c", "a b b c"),
+      ("a b+ c ", "a b b b c", "a b b b c"),
+      ("a b+ b c", "a b b c", "a b b c"),
+      ("a b+ b c", "a b b b c", "a b b b c"),
+      ("a b? b c", "a b c", "a b c"),
+      ("a b? b c", "a b b c", "a b b c"),
+      ("a b{0,1} c", "a c", "a c"),
+      ("a b{0,1} c", "a b c", "a b c"),
+      ("a (b | c) d", "a b d", "a b d"),
+      ("a (b | c) d", "a c d", "a c d"),
+      ("a (b | c)? d", "a d ", "a d"),
+      ("a (b | c)? d", "a b d", "a b d"),
+      ("a (b | c)? d", "a c d", "a c d"),
+      ("a (b | c)* d", "a d", "a d"),
+      ("a (b | c)* d", "a b d", "a b d"),
+      ("a (b | c)* d", "a b c d", "a b c d"),
+      ("a (b | c)* d", "a c b d", "a c b d"),
+      ("a (b | c)* d", "a b b b d", "a b b b d"),
+      ("a (b | c)* d", "a b c b c d", "a b c b c d"),
+      ("a b | c d", "a b c", "a b"),
+      ("a b | c d", "a c d", "c d"),
+      ("a []*? c", "a b c a b c", "a b c"),
+      ("a []* c", "a b c a b c", "a b c a b c"),
+      ("a []+? c", "a b c a b c", "a b c"),
+      ("a []+ c", "a b c a b c", "a b c a b c"),
+      ("a []*? c", "a c b c a b c", "a c"),
+      ("a []* c", "a c b c a b c", "a c b c a b c"),
+      ("a []+? c", "a c b c a b c", "a c b c"),
+      ("a []+ c", "a c b c a b c", "a c b c a b c"),
+      ("(a+ | b)*", "a b", "a b"),
+      ("(a+ | b){0,}", "a b", "a b"),
+      ("(a+ | b)+", "a b", "a b"),
+      ("(a+ | b){1,}", "a b", "a b"),
+      ("(a+ | b)?", "a b", "a"),
+      ("(a+ | b){0,1}", "a b", "a"),
+      ("(a | b | c | d | e) f", "e f", "e f"),
+      ("(a b | a b*) b c", "a b c", "a b c"),
+    )
+    forAll (patterns) { (pattern: String, string: String, expected: String) =>
+      val ee = TestUtils.mkExtractorEngine(string)
+      val results = ee.query(pattern)
+      val actual = TestUtils.mkString(results, ee)
+      actual should equal (expected)
+    }
+  }
+
+}
+
+object TestUtils {
+
+  val config = ConfigFactory.load()
+  val allTokenFields       = config[List[String]]("odinson.compiler.allTokenFields")
+  val documentIdField      = config[String]("odinson.index.documentIdField")
+  val sentenceIdField      = config[String]("odinson.index.sentenceIdField")
+  val sentenceLengthField  = config[String]("odinson.index.sentenceLengthField")
+  val rawTokenField        = config[String]("odinson.index.rawTokenField")
+  val normalizedTokenField = config[String]("odinson.index.normalizedTokenField")
+  val wordTokenField       = config[String]("odinson.index.wordTokenField")
+
+  val defaultTokenField    = config[String]("odinson.compiler.defaultTokenField")
+  val dependenciesField    = config[String]("odinson.compiler.dependenciesField")
+  val incomingTokenField   = config[String]("odinson.compiler.incomingTokenField")
+  val outgoingTokenField   = config[String]("odinson.compiler.outgoingTokenField")
+
+  val normalizeQueriesToDefaultField = config[Boolean]("odinson.compiler.normalizeQueriesToDefaultField")
+
+  /**
+    * Converts [[ai.lum.odinson.lucene.OdinResults]] to a string.  Used to compare actual to expected results.
+    */
+  def mkString(results: OdinResults, engine: ExtractorEngine): String = if (results.totalHits == 0) "" else {
+    val allMatchingSpans = for {
+      scoreDoc <- results.scoreDocs
+      tokens = getTokens(scoreDoc, engine)
+      swc <- scoreDoc.matches
+    } yield {
+      tokens
+        .slice(swc.span.start, swc.span.end)
+        .mkString(" ")
+    }
+
+    allMatchingSpans.mkString(" ")
+  }
+
+  /**
+    * Retrieves tokens from an [[ai.lum.odinson.lucene.search.OdinsonScoreDoc]] using an [[ai.lum.odinson.ExtractorEngine]].
+    */
+  def getTokens(scoreDoc: OdinsonScoreDoc, engine: ExtractorEngine): Array[String] = {
+    val doc = engine.indexSearcher.doc(scoreDoc.doc)
+    // FIXME: retrieve tokens without relying on term vectors
+    val tvs = engine.indexReader.getTermVectors(scoreDoc.doc)
+    val sentenceText = doc.getField(wordTokenField).stringValue
+    val ts = TokenSources.getTokenStream(wordTokenField, tvs, sentenceText, new WhitespaceAnalyzer, -1)
+    TokenStreamUtils.getTokens(ts).toArray
+  }
+
+  /**
+    * Constructs an [[ai.lum.odinson.ExtractorEngine]] from a single-doc in-memory index ([[org.apache.lucene.store.RAMDirectory]])
+    */
+  def mkExtractorEngine(text: String): ExtractorEngine = {
+
+    val memWriter = OdinsonIndexWriter.inMemory
+    writeDoc(memWriter, text)
+    
+    val reader = DirectoryReader.open(memWriter.directory)
+
+    val indexSearcher = new OdinsonIndexSearcher(reader)
+    val compiler = new QueryCompiler(
+      allTokenFields = allTokenFields,
+      defaultTokenField = defaultTokenField,
+      sentenceLengthField = sentenceLengthField,
+      dependenciesField = dependenciesField,
+      incomingTokenField = incomingTokenField,
+      outgoingTokenField = outgoingTokenField,
+      dependenciesVocabulary = memWriter.vocabulary,
+      normalizeQueriesToDefaultField = normalizeQueriesToDefaultField
+    )
+
+    val jdbcUrl = config[String]("odinson.state.jdbc.url")
+    val state = new State(jdbcUrl)
+    state.init()
+    compiler.setState(state)
+    new ExtractorEngine(indexSearcher, compiler, state, documentIdField)
+  }
+
+  /**
+    * Writes string to in-memory index ([[org.apache.lucene.store.RAMDirectory]]), and commits result.
+    */
+  def writeDoc(writer: OdinsonIndexWriter, text: String): Unit = {
+    val doc = mkSentenceDoc(text)
+
+    writer.addDocuments(Seq(doc))
+    writer.commit()
+  }
+
+  /**
+    * Creates a simple Odison-style [[org.apache.lucene.document.Document]] from a space-delimited string.
+    */
+  def mkSentenceDoc(text: String): LuceneDocument = {
+
+    val toks: Array[String] = text.split(" ")
+    val sent = new LuceneDocument
+    sent.add(new StoredField(documentIdField, "doc-1"))
+    sent.add(new StoredField(sentenceIdField, "sent-1"))
+    sent.add(new NumericDocValuesField(sentenceLengthField, toks.size.toLong))
+    sent.add(new TextField(rawTokenField, new OdinsonTokenStream(toks)))
+    // we want to index and store the words for displaying in the shell
+    sent.add(new TextField(wordTokenField, text, Store.YES))
+    sent.add(new TextField(normalizedTokenField, new NormalizedTokenStream(toks, toks)))
+    sent
+  }
+
+}

--- a/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
@@ -132,7 +132,7 @@ object TestUtils {
 
     val memWriter = OdinsonIndexWriter.inMemory
     writeDoc(memWriter, text)
-    
+
     val reader = DirectoryReader.open(memWriter.directory)
 
     val indexSearcher = new OdinsonIndexSearcher(reader)

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -39,7 +39,6 @@ object IndexDocuments extends App with LazyLogging {
   val incomingTokenField   = config[String]("odinson.index.incomingTokenField")
   val outgoingTokenField   = config[String]("odinson.index.outgoingTokenField")
   val dependenciesField    = config[String]("odinson.index.dependenciesField")
-  val dependenciesVocabularyFile   = config[File]("odinson.index.dependenciesVocabulary")
   val sortedDocValuesFieldMaxSize  = config[Int]("odinson.index.sortedDocValuesFieldMaxSize")
   val maxNumberOfTokensPerSentence = config[Int]("odinson.index.maxNumberOfTokensPerSentence")
 
@@ -70,7 +69,7 @@ object IndexDocuments extends App with LazyLogging {
 
   }
 
-  writer.close(dependenciesVocabularyFile)
+  writer.close
 
   // fin
 

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -47,7 +47,7 @@ object IndexDocuments extends App with LazyLogging {
 
   implicit val formats = DefaultFormats
 
-  val writer = new OdinsonIndexWriter(indexDir, dependenciesVocabularyFile)
+  val writer = OdinsonIndexWriter.fromConfig
 
   // serialized org.clulab.processors.Document or Document json
   val SUPPORTED_EXTENSIONS = "(?i).*?\\.(ser|json)$"
@@ -70,7 +70,7 @@ object IndexDocuments extends App with LazyLogging {
 
   }
 
-  writer.close()
+  writer.close(dependenciesVocabularyFile)
 
   // fin
 

--- a/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
@@ -2,6 +2,7 @@ package ai.lum.odinson.extra
 
 import java.io.File
 import java.text.NumberFormat
+
 import scala.util.control.NonFatal
 import scala.collection.immutable.ListMap
 import jline.console.ConsoleReader
@@ -15,6 +16,7 @@ import ai.lum.odinson.lucene.search._
 import ai.lum.odinson.lucene.search.highlight.ConsoleHighlighter
 import ai.lum.odinson.BuildInfo
 import ai.lum.odinson.ExtractorEngine
+import ai.lum.odinson.digraph.Vocabulary
 import ai.lum.odinson.utils.ConfigFactory
 
 
@@ -36,7 +38,7 @@ object Shell extends App {
   var maxMatchesDisplay = config[Int]("odinson.shell.maxMatchesDisplay")
   val prompt = config[String]("odinson.shell.prompt")
   val history = new FileHistory(config[File]("odinson.shell.history"))
-  val dependenciesVocabulary = config[File]("odinson.index.dependenciesVocabulary")
+  val dependenciesVocabulary = new File(config[File]("odinson.indexDir"), Vocabulary.FILE_NAME)
 
   // we must flush the history before exiting
   sys.addShutdownHook {

--- a/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
@@ -38,7 +38,6 @@ object Shell extends App {
   var maxMatchesDisplay = config[Int]("odinson.shell.maxMatchesDisplay")
   val prompt = config[String]("odinson.shell.prompt")
   val history = new FileHistory(config[File]("odinson.shell.history"))
-  val dependenciesVocabulary = new File(config[File]("odinson.indexDir"), Vocabulary.FILE_NAME)
 
   // we must flush the history before exiting
   sys.addShutdownHook {
@@ -53,9 +52,10 @@ object Shell extends App {
   def fmt(n: Float): String = numFormatter.format(n.toDouble)
 
   // retrieve dependencies
+  val dependenciesVocabulary = Vocabulary.fromIndex(config[File]("odinson.indexDir"))
+
   val dependencies = dependenciesVocabulary
-    .readString()
-    .lines
+    .terms
     .flatMap(dep => Seq(s">$dep", s"<$dep"))
 
   // autocomplete


### PR DESCRIPTION
These changes add support for in-memory indexes via Lucene's [`RAMDirectory`](https://lucene.apache.org/core/6_6_5/core/org/apache/lucene/store/RAMDirectory.html).  

Along with simplifying testing aspects of system, this serves as an enabling step towards #16.