### PR TITLE
Added computeTotalHits configuration

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -15,6 +15,9 @@ odinson {
   # how many search results to display per page
   pageSize = 20
 
+  # should a precise totalHits be calculated per query
+  computeTotalHits = true
+
   state {
     jdbc {
       url = "jdbc:h2:mem:odinson"

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -165,7 +165,8 @@ object ExtractorEngine {
   def fromConfig(config: Config): ExtractorEngine = {
     val indexDir = config[Path]("indexDir")
     val indexReader = DirectoryReader.open(FSDirectory.open(indexDir))
-    val indexSearcher = new OdinsonIndexSearcher(indexReader)
+    val computeTotalHits = config[Boolean]("computeTotalHits")
+    val indexSearcher = new OdinsonIndexSearcher(indexReader, computeTotalHits)
     val compiler = QueryCompiler.fromConfig(config)
     val jdbcUrl = config[String]("state.jdbc.url")
     val state = new State(jdbcUrl)

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
@@ -3,26 +3,26 @@ package ai.lum.odinson.lucene.search
 import java.util.Arrays
 import org.apache.lucene.index._
 import org.apache.lucene.search._
-import org.apache.lucene.util.PriorityQueue
 import ai.lum.odinson.lucene._
-
+import org.apache.lucene.search.CollectionTerminatedException
 
 
 class OdinsonCollector(
-    private val collectedResults: Array[OdinsonScoreDoc],
-    private val after: Int
-) extends Collector {
+                        private val collectedResults: Array[OdinsonScoreDoc],
+                        private val after: Int,
+                        private val computeTotalHits: Boolean,
+                      ) extends Collector {
 
-  def this(numHits: Int, after: Int) = {
-    this(new Array[OdinsonScoreDoc](numHits), after)
+  def this(numHits: Int, after: Int, computeTotalHits: Boolean) = {
+    this(new Array[OdinsonScoreDoc](numHits), after, computeTotalHits)
   }
 
-  def this(numHits: Int) = {
-    this(numHits, -1)
+  def this(numHits: Int, computeTotalHits: Boolean) = {
+    this(numHits, -1, computeTotalHits)
   }
 
-  def this(numHits: Int, afterDoc: OdinsonScoreDoc) = {
-    this(numHits, if (afterDoc == null) -1 else afterDoc.doc)
+  def this(numHits: Int, afterDoc: OdinsonScoreDoc, computeTotalHits: Boolean) = {
+    this(numHits, if (afterDoc == null) -1 else afterDoc.doc, computeTotalHits)
   }
 
   private var totalHits: Int = 0
@@ -45,30 +45,80 @@ class OdinsonCollector(
 
   abstract class OdinsonLeafCollector extends LeafCollector {
     protected var scorer: OdinsonScorer = null
+
     override def setScorer(scorer: Scorer): Unit = scorer match {
       case s: OdinsonScorer => this.scorer = s
       case _ => sys.error("unsupported scorer")
     }
   }
 
+  case class TotalHitsCalculatingLeafCollector(docBase: Int, afterDoc: Int) extends OdinsonLeafCollector {
+    def collect(doc: Int): Unit = {
+      totalHits += 1
+      if (collectedHits >= collectedResults.length || doc <= afterDoc) {
+        return // don't terminate, we want to keep collecting for accurate totalHits count
+      }
+      collectedResults(collectedHits) = new OdinsonScoreDoc(
+        doc = doc + docBase,
+        score = scorer.score(),
+        shardIndex = -1,
+        matches = scorer.getMatches(),
+        segmentDocId = doc,
+        segmentDocBase = docBase,
+      )
+      collectedHits += 1
+    }
+  }
+
+  case class EarlyTerminationLeafCollector(docBase: Int, afterDoc: Int) extends OdinsonLeafCollector {
+    def collect(doc: Int): Unit = {
+      if (collectedHits >= collectedResults.length) {
+        throw new CollectionTerminatedException() // terminate, since all required results have been collected
+      }
+      if (doc <= afterDoc) {
+        return
+      }
+      collectedResults(collectedHits) = new OdinsonScoreDoc(
+        doc = doc + docBase,
+        score = scorer.score(),
+        shardIndex = -1,
+        matches = scorer.getMatches(),
+        segmentDocId = doc,
+        segmentDocBase = docBase,
+      )
+      collectedHits += 1
+      totalHits += 1
+    }
+  }
+
+  case class NOPCollector() extends LeafCollector {
+    def setScorer(scorer: Scorer): Unit = {}
+
+    def collect(doc: Int): Unit = throw new CollectionTerminatedException()
+  }
+
   def getLeafCollector(context: LeafReaderContext): LeafCollector = {
     val docBase = context.docBase
     val afterDoc = after - context.docBase
-    new OdinsonLeafCollector {
-      def collect(doc: Int): Unit = {
-        totalHits += 1
-        if (collectedHits >= collectedResults.length || doc <= afterDoc) {
-          return
+
+    if (computeTotalHits) {
+      TotalHitsCalculatingLeafCollector(docBase, afterDoc)
+    } else {
+      var skipEntireSegment = false
+
+      // based on the docBase of the next reader in line, we might want to skip this entire reader
+      // if all the indexes here are before the specified 'after' value
+      if (context.parent.isTopLevel && context.parent.leaves().size() > context.ordInParent + 1) {
+        val nextLeafContext = context.parent.leaves().get(context.ordInParent + 1)
+        if (nextLeafContext.docBase >= after + 1) {
+          skipEntireSegment = true
         }
-        collectedResults(collectedHits) = new OdinsonScoreDoc(
-          doc = doc + docBase,
-          score = scorer.score(),
-          shardIndex = -1,
-          matches = scorer.getMatches(),
-          segmentDocId = doc,
-          segmentDocBase = docBase,
-        )
-        collectedHits += 1
+      }
+
+      if (skipEntireSegment) {
+        NOPCollector()
+      } else {
+        EarlyTerminationLeafCollector(docBase, afterDoc)
       }
     }
   }

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
@@ -110,7 +110,7 @@ class OdinsonCollector(
       // if all the indexes here are before the specified 'after' value
       if (context.parent.isTopLevel && context.parent.leaves().size() > context.ordInParent + 1) {
         val nextLeafContext = context.parent.leaves().get(context.ordInParent + 1)
-        if (nextLeafContext.docBase >= after + 1) {
+        if (nextLeafContext.docBase <= after + 1) {
           skipEntireSegment = true
         }
       }

--- a/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestPatterns.scala
@@ -76,8 +76,7 @@ object TestUtils {
     writeDoc(memWriter, text)
 
     val reader = DirectoryReader.open(memWriter.directory)
-
-    val indexSearcher = new OdinsonIndexSearcher(reader)
+    val indexSearcher = new OdinsonIndexSearcher(reader, computeTotalHits = true)
     val compiler = new QueryCompiler(
       allTokenFields = allTokenFields,
       defaultTokenField = rawTokenField, // raw is the default field for testing purposes


### PR DESCRIPTION
The current default behavior is to compute `totalHits` on each query. This PR adds a configuration option `computeTotalHits = true` (the default is the existing behavior). 

The reason for this PR is because the engine becomes unusable on very large data sets when many matches exist (wikipedia for example, with a rather general query). With this fix, by setting `computeTotalHits = false` you can get fast results without having to wait for the computation of `totalHits`. 