### PR TITLE
Added flag to index in order of the external document id

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -91,6 +91,11 @@ odinson {
     // See https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/document/SortedDocValuesField.html
     sortedDocValuesFieldMaxSize = 32766
 
+    // When indexing make sure to add the documents in the order of the external document id, so that the
+    // results returned by queries will be ordered by external document id
+    // WARNING: turning this on will slow the indexing process as documents will be parsed twice
+    synchronizeOrderWithDocumentId = false
+
   }
 
 }


### PR DESCRIPTION
This PR adds a new configuration flag that influences the order in which documents are loaded during indexing. This flag enables the ability to load the documents based on the document id, which will cause it to match (in order) to the odinson id, consequentially making search queries results being ordered by the external document id.