### PR TITLE
Optionally prettify json & add Content-Type: application/json header

### DIFF
--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -24,7 +24,7 @@ GET     /api/sentence                   controllers.OdinsonController.sentenceJs
 GET     /api/numdocs                    controllers.OdinsonController.numDocs
 
 # corpus info and statistics
-GET     /api/corpus                    controllers.OdinsonController.corpusInfo
+GET     /api/corpus                    controllers.OdinsonController.corpusInfo(pretty: Option[Boolean])
 
 # misc
 GET     /api/dependencies-vocabulary    controllers.OdinsonController.dependenciesVocabulary(pretty: Option[Boolean])

--- a/backend/public/schema/odinson.yaml
+++ b/backend/public/schema/odinson.yaml
@@ -325,6 +325,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/BuildInfo'
 
+  /api/corpus:
+    get:
+      tags:
+        - info
+      summary: Information about the current corpus.
+      description: Provides information about the current corpus.
+      operationId: corpus
+      responses:
+        '200':
+          description: "A JSON object containing corpus information."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CorpusInfo'
+
 components:
   schemas:
 
@@ -786,3 +801,25 @@ components:
           type: string
           description: "Date in milliseconds (since unix epoch)."
           example: "1526875138573"
+
+    CorpusInfo:
+      type: object
+      required:
+        - numDocs
+        - corpus
+        - distinctDependencyRelations
+      properties:
+        numDocs:
+          type: integer
+          format: int32
+          description: "The total number of documents (num. docs = num. sentences) in the corpus."
+          example: 10000
+        corpus:
+          type: string
+          description: "The name of the parent directory of the current corpus."
+          example: "demo-index"
+        distinctDependencyRelations:
+          type: integer
+          format: int32
+          description: "The number of dependency relation types indexed in the corpus."
+          example: 134


### PR DESCRIPTION
## Summary of changes
- Uniformly handle `?pretty=true`
- Add `Content-Type application/json` to all relevant responses