### PR TITLE
Resolves #35

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -10,6 +10,21 @@ play {
     # The server provider class name
     provider = "play.core.server.AkkaHttpServerProvider"
 
+    http {
+      # The HTTP port of the server. Use a value of "disabled" if the server
+      # shouldn't bind an HTTP port.
+      port = 9000
+
+      # The interface address to bind to.
+      address = "0.0.0.0"
+
+      # The idle timeout for an open connection after which it will be closed
+      # Set to null or "infinite" to disable the timeout, but notice that this
+      # is not encouraged since timeout are important mechanisms to protect your
+      # servers from malicious attacks or programming mistakes.
+      idleTimeout = "infinite"
+    }
+
     akka {
 
       http {
@@ -19,15 +34,15 @@ play {
         # The secret key is used to sign Play's session cookie.
         # This must be changed for production, but we don't recommend you change it in this file.
 
-        address = "localhost"
+        address = ${play.server.http.address}
+        port    = ${play.server.http.port}
       }
 
       # How long to wait when binding to the listening socket
       bindTimeout = 5 seconds
 
       # How long a request takes until it times out. Set to null or "infinite" to disable the timeout.
-      requestTimeout = infinite
-
+      requestTimeout = "infinite"
       # Enables/disables automatic handling of HEAD requests.
       # If this setting is enabled the server dispatches HEAD requests as GET
       # requests to the application and automatically strips off all message
@@ -127,3 +142,4 @@ contexts {
     fixed-pool-size = 2
   }
 }
+

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -1,301 +1,124 @@
-http.address = "localhost"
-# This is the main configuration file for the application.
-# https://www.playframework.com/documentation/latest/ConfigFile
-# ~~~~~
-# Play uses HOCON as its configuration file format.  HOCON has a number
-# of advantages over other config formats, but there are two things that
-# can be used when modifying settings.
-#
-# You can include other configuration files in this main application.conf file:
-#include "extra-config.conf"
-#
-# You can declare variables and substitute for them:
-#mykey = ${some.value}
-#
-# And if an environment variable exists when there is no other subsitution, then
-# HOCON will fall back to substituting environment variable:
-#mykey = ${JAVA_HOME}
+# Configuration for Play's AkkaHttpServer
+play {
 
-## Akka
-# https://www.playframework.com/documentation/latest/ScalaAkka#Configuration
-# https://www.playframework.com/documentation/latest/JavaAkka#Configuration
-# ~~~~~
-# Play uses Akka internally and exposes Akka Streams and actors in Websockets and
-# other streaming HTTP responses.
-akka {
-  # "akka.log-config-on-start" is extraordinarly useful because it log the complete
-  # configuration at INFO level, including defaults and overrides, so it s worth
-  # putting at the very top.
-  #
-  # Put the following in your conf/logback-test.xml file:
-  #
-  # <logger name="akka.actor" level="INFO" />
-  #
-  # And then uncomment this line to debug the configuration.
-  #
-  #log-config-on-start = true
-}
-
-## Secret key
-# http://www.playframework.com/documentation/latest/ApplicationSecret
-# ~~~~~
-# The secret key is used to sign Play's session cookie.
-# This must be changed for production, but we don't recommend you change it in this file.
-
-play.http.secret.key = "not-production-ready"
-play.http.secret.key = ${?APPLICATION_SECRET}
-## Modules
-# https://www.playframework.com/documentation/latest/Modules
-# ~~~~~
-# Control which modules are loaded when Play starts.  Note that modules are
-# the replacement for "GlobalSettings", which are deprecated in 2.5.x.
-# Please see https://www.playframework.com/documentation/latest/GlobalSettings
-# for more information.
-#
-# You can also extend Play functionality by using one of the publically available
-# Play modules: https://playframework.com/documentation/latest/ModuleDirectory
-play.modules {
-  # By default, Play will load any class called Module that is defined
-  # in the root package (the "app" directory), or you can define them
-  # explicitly below.
-  # If there are any built-in modules that you want to enable, you can list them here.
-  #enabled += my.application.Module
-  #enabled += "com.github.tototoshi.play2.json4s.native.Json4sModule"
-  # If there are any built-in modules that you want to disable, you can list them here.
-  #disabled += ""
-}
-
-# Map static resources from the /public folder to the /assets URL path
-play.assets {
-  path = "/public"
-  urlPrefix = "/assets"
-}
-
-## IDE
-# https://www.playframework.com/documentation/latest/IDE
-# ~~~~~
-# Depending on your IDE, you can add a hyperlink for errors that will jump you
-# directly to the code location in the IDE in dev mode. The following line makes
-# use of the IntelliJ IDEA REST interface:
-#play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
-
-## Internationalisation
-# https://www.playframework.com/documentation/latest/JavaI18N
-# https://www.playframework.com/documentation/latest/ScalaI18N
-# ~~~~~
-# Play comes with its own i18n settings, which allow the user's preferred language
-# to map through to internal messages, or allow the language to be stored in a cookie.
-play.i18n {
-  # The application languages
-  langs = [ "en" ]
-
-  # Whether the language cookie should be secure or not
-  #langCookieSecure = true
-
-  # Whether the HTTP only attribute of the cookie should be set to true
-  #langCookieHttpOnly = true
-}
-
-## Play HTTP settings
-# ~~~~~
-play.http {
-  ## Router
-  # https://www.playframework.com/documentation/latest/JavaRouting
-  # https://www.playframework.com/documentation/latest/ScalaRouting
-  # ~~~~~
-  # Define the Router object to use for this application.
-  # This router will be looked up first when the application is starting up,
-  # so make sure this is the entry point.
-  # Furthermore, it's assumed your route file is named properly.
-  # So for an application router like `my.application.Router`,
-  # you may need to define a router file `conf/my.application.routes`.
-  # Default to Routes in the root package (aka "apps" folder) (and conf/routes)
-  #router = my.application.Router
-
-  ## Action Creator
-  # https://www.playframework.com/documentation/latest/JavaActionCreator
-  # ~~~~~
-  #actionCreator = null
-
-  ## ErrorHandler
-  # https://www.playframework.com/documentation/latest/JavaRouting
-  # https://www.playframework.com/documentation/latest/ScalaRouting
-  # ~~~~~
-  # If null, will attempt to load a class called ErrorHandler in the root package,
-  #errorHandler = null
-
-  ## Filters
-  # https://www.playframework.com/documentation/latest/ScalaHttpFilters
-  # https://www.playframework.com/documentation/latest/JavaHttpFilters
-  # ~~~~~
-  # Filters run code on every request. They can be used to perform
-  # common logic for all your actions, e.g. adding common headers.
-  # Defaults to "Filters" in the root package (aka "apps" folder)
-  # Alternatively you can explicitly register a class here.
-  #filters = my.application.Filters
-
-  ## Session & Flash
-  # https://www.playframework.com/documentation/latest/JavaSessionFlash
-  # https://www.playframework.com/documentation/latest/ScalaSessionFlash
-  # ~~~~~
-  session {
-    # Sets the cookie to be sent only over HTTPS.
-    #secure = true
-
-    # Sets the cookie to be accessed only by the server.
-    #httpOnly = true
-
-    # Sets the max-age field of the cookie to 5 minutes.
-    # NOTE: this only sets when the browser will discard the cookie. Play will consider any
-    # cookie value with a valid signature to be a valid session forever. To implement a server side session timeout,
-    # you need to put a timestamp in the session and check it at regular intervals to possibly expire it.
-    #maxAge = 300
-
-    # Sets the domain on the session cookie.
-    #domain = "example.com"
+  http {
+    secret.key = "not-production-ready"
+    secret.key = ${?APPLICATION_SECRET}
   }
 
-  flash {
-    # Sets the cookie to be sent only over HTTPS.
-    #secure = true
+  server {
+    # The server provider class name
+    provider = "play.core.server.AkkaHttpServerProvider"
 
-    # Sets the cookie to be accessed only by the server.
-    #httpOnly = true
-  }
-}
+    akka {
 
-## Netty Provider
-# https://www.playframework.com/documentation/latest/SettingsNetty
-# ~~~~~
-play.server.netty {
-  # Whether the Netty wire should be logged
-  #log.wire = true
+      http {
+        ## Secret key
+        # http://www.playframework.com/documentation/latest/ApplicationSecret
+        # ~~~~~
+        # The secret key is used to sign Play's session cookie.
+        # This must be changed for production, but we don't recommend you change it in this file.
 
-  # If you run Play on Linux, you can use Netty's native socket transport
-  # for higher performance with less garbage.
-  #transport = "native"
-}
+        address = "localhost"
+      }
 
-## WS (HTTP Client)
-# https://www.playframework.com/documentation/latest/ScalaWS#Configuring-WS
-# ~~~~~
-# The HTTP client primarily used for REST APIs.  The default client can be
-# configured directly, but you can also create different client instances
-# with customized settings. You must enable this by adding to build.sbt:
-#
-# libraryDependencies += ws // or javaWs if using java
-#
-play.ws {
-  # Sets HTTP requests not to follow 302 requests
-  #followRedirects = false
+      # How long to wait when binding to the listening socket
+      bindTimeout = 5 seconds
 
-  # Sets the maximum number of open HTTP connections for the client.
-  #ahc.maxConnectionsTotal = 50
+      # How long a request takes until it times out. Set to null or "infinite" to disable the timeout.
+      requestTimeout = infinite
 
-  ## WS SSL
-  # https://www.playframework.com/documentation/latest/WsSSL
-  # ~~~~~
-  ssl {
-    # Configuring HTTPS with Play WS does not require programming.  You can
-    # set up both trustManager and keyManager for mutual authentication, and
-    # turn on JSSE debugging in development with a reload.
-    #debug.handshake = true
-    #trustManager = {
-    #  stores = [
-    #    { type = "JKS", path = "exampletrust.jks" }
-    #  ]
-    #}
-  }
-}
+      # Enables/disables automatic handling of HEAD requests.
+      # If this setting is enabled the server dispatches HEAD requests as GET
+      # requests to the application and automatically strips off all message
+      # bodies from outgoing responses.
+      # Note that, even when this setting is off the server will never send
+      # out message bodies on responses to HEAD requests.
+      transparent-head-requests = off
 
-## Cache
-# https://www.playframework.com/documentation/latest/JavaCache
-# https://www.playframework.com/documentation/latest/ScalaCache
-# ~~~~~
-# Play comes with an integrated cache API that can reduce the operational
-# overhead of repeated requests. You must enable this by adding to build.sbt:
-#
-# libraryDependencies += cache
-#
-play.cache {
-  # If you want to bind several caches, you can bind the individually
-  #bindCaches = ["db-cache", "user-cache", "session-cache"]
-}
+      # If this setting is empty the server only accepts requests that carry a
+      # non-empty `Host` header. Otherwise it responds with `400 Bad Request`.
+      # Set to a non-empty value to be used in lieu of a missing or empty `Host`
+      # header to make the server accept such requests.
+      # Note that the server will never accept HTTP/1.1 request without a `Host`
+      # header, i.e. this setting only affects HTTP/1.1 requests with an empty
+      # `Host` header as well as HTTP/1.0 requests.
+      # Examples: `www.spray.io` or `example.com:8080`
+      default-host-header = ""
 
-## Filters
-# https://www.playframework.com/documentation/latest/Filters
-# ~~~~~
-# There are a number of built-in filters that can be enabled and configured
-# to give Play greater security.  You must enable this by adding to build.sbt:
-#
-# libraryDependencies += filters
-#
-play.filters {
-  ## CORS filter configuration
-  # https://www.playframework.com/documentation/latest/CorsFilter
-  # ~~~~~
-  # CORS is a protocol that allows web applications to make requests from the browser
-  # across different domains.
-  # NOTE: You MUST apply the CORS configuration before the CSRF filter, as CSRF has
-  # dependencies on CORS settings.
-  cors {
-    # Filter paths by a whitelist of path prefixes
-    #pathPrefixes = ["/some/path", ...]
+      # The default value of the `Server` header to produce if no
+      # explicit `Server`-header was included in a response.
+      # If this value is null and no header was included in
+      # the request, no `Server` header will be rendered at all.
+      server-header = null
+      server-header = ${?play.server.server-header}
 
-    # The allowed origins. If null, all origins are allowed.
-    #allowedOrigins = ["http://www.example.com"]
+      # Configures the processing mode when encountering illegal characters in
+      # header value of response.
+      #
+      # Supported mode:
+      # `error`  : default mode, throw an ParsingException and terminate the processing
+      # `warn`   : ignore the illegal characters in response header value and log a warning message
+      # `ignore` : just ignore the illegal characters in response header value
+      illegal-response-header-value-processing-mode = warn
 
-    # The allowed HTTP methods. If null, all methods are allowed
-    #allowedHttpMethods = ["GET", "POST"]
+      # This setting is set in `akka.http.server.parsing.max-content-length`
+      # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
+      max-content-length = infinite
+
+      # This setting is set in `akka.http.server.parsing.max-header-value-length`
+      # and it limits the length of HTTP header values.
+      max-header-value-length = 8k
+
+
+      # Enables/disables inclusion of an Tls-Session-Info header in parsed
+      # messages over Tls transports (i.e., HttpRequest on server side and
+      # HttpResponse on client side).
+      #
+      # See Akka HTTP `akka.http.server.parsing.tls-session-info-header` for
+      # more information about how this works.
+      tls-session-info-header = on
+    }
   }
 
-  ## CSRF Filter
-  # https://www.playframework.com/documentation/latest/ScalaCsrf#Applying-a-global-CSRF-filter
-  # https://www.playframework.com/documentation/latest/JavaCsrf#Applying-a-global-CSRF-filter
+  ## Internationalisation
+  # https://www.playframework.com/documentation/latest/JavaI18N
+  # https://www.playframework.com/documentation/latest/ScalaI18N
   # ~~~~~
-  # Play supports multiple methods for verifying that a request is not a CSRF request.
-  # The primary mechanism is a CSRF token. This token gets placed either in the query string
-  # or body of every form submitted, and also gets placed in the users session.
-  # Play then verifies that both tokens are present and match.
-  csrf {
-    # Sets the cookie to be sent only over HTTPS
-    #cookie.secure = true
+  # Play comes with its own i18n settings, which allow the user's preferred language
+  # to map through to internal messages, or allow the language to be stored in a cookie.
+  i18n {
+    # The application languages
+    langs = [ "en" ]
 
-    # Defaults to CSRFErrorHandler in the root package.
-    #errorHandler = MyCSRFErrorHandler
+    # Whether the language cookie should be secure or not
+    #langCookieSecure = true
+
+    # Whether the HTTP only attribute of the cookie should be set to true
+    #langCookieHttpOnly = true
   }
 
-  ## Security headers filter configuration
-  # https://www.playframework.com/documentation/latest/SecurityHeaders
-  # ~~~~~
-  # Defines security headers that prevent XSS attacks.
-  # If enabled, then all options are set to the below configuration by default:
-  headers {
-    # The X-Frame-Options header. If null, the header is not set.
-    #frameOptions = "DENY"
-
-    # The X-XSS-Protection header. If null, the header is not set.
-    #xssProtection = "1; mode=block"
-
-    # The X-Content-Type-Options header. If null, the header is not set.
-    #contentTypeOptions = "nosniff"
-
-    # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
-    #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    contentSecurityPolicy = null #"default-src 'self'"
+  modules {
+    # By default, Play will load any class called Module that is defined
+    # in the root package (the "app" directory), or you can define them
+    # explicitly below.
+    # If there are any built-in modules that you want to enable, you can list them here.
+    #enabled += my.application.Module
+    #enabled += "com.github.tototoshi.play2.json4s.native.Json4sModule"
+    # If there are any built-in modules that you want to disable, you can list them here.
+    #disabled += ""
+  }
+  
+  # Map static resources from the /public folder to the /assets URL path
+  assets {
+    path = "/public"
+    urlPrefix = "/assets"
   }
 
-  ## Allowed hosts filter configuration
-  # https://www.playframework.com/documentation/latest/AllowedHostsFilter
-  # ~~~~~
-  # Play provides a filter that lets you configure which hosts can access your application.
-  # This is useful to prevent cache poisoning attacks.
   hosts {
     # Allow requests to example.com, its subdomains, and localhost:9000.
     # FIXME: restrict for production
-	allowed = ["."] #, "localhost:9000"]
+    allowed = ["."] #, "localhost:9000"]
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,13 @@ lazy val backend = project
   .dependsOn(core % "test->test;compile->compile")
   .dependsOn(extra)
   .settings(commonSettings)
+  .settings(
+    // Dev settings which are read prior to loading of config.
+    // See https://www.playframework.com/documentation/2.7.x/ConfigFile#Using-with-the-run-command
+    PlayKeys.devSettings += "play.server.http.port" -> "9000",
+    PlayKeys.devSettings += "play.server.http.address" -> "0.0.0.0",
+    PlayKeys.devSettings += "play.server.http.idleTimeout" -> "infinite"
+  )
 
 
 lazy val restApi = taskKey[Unit]("Launches the odinson REST API.")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")


### PR DESCRIPTION
These changes resolve #35.

[In development mode, the HTTP server is started before the config is available](https://www.playframework.com/documentation/2.7.x/ConfigFile#HTTP-server-settings-in-application.conf), so changes to the server (timeouts, host, ports, etc.) must be made in [`build.sbt`](https://github.com/lum-ai/odinson/blob/d3e94a06c36e7e9ff9fc937cda4685ef53b317d6/build.sbt#L84-L90)