### PR TITLE
Fixes allowed hosts configuration in application.conf

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -129,11 +129,12 @@ play {
     path = "/public"
     urlPrefix = "/assets"
   }
-
-  hosts {
-    # Allow requests to example.com, its subdomains, and localhost:9000.
-    # FIXME: restrict for production
-    allowed = ["."] #, "localhost:9000"]
+  filters {
+    hosts {
+      # Allow requests to example.com, its subdomains, and localhost:9000.
+      # FIXME: restrict for production
+      allowed = ["."] #, "localhost:9000"]
+    }
   }
 }
 


### PR DESCRIPTION
With the latest changes to configuration introduced in #43, there is a regression regarding allowed hosts. Accessing the back end can only be done through `localhost`, everything else will be blocked by the `AllowedHostsFilter`.

The issue is in the configuration, the `filters` part of the full property name is missing.
See: https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter

Before this PR, the property used to allow all hosts was: `play.hosts.allowed`
This PR changes it to the proper: `play.filters.hosts.allowed`