### PR TITLE
helper method to make memory indexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Added `ExtractorEngine.inMemory(...)` to help build an index in memory.
 
 ## [0.2.3] - 2020-03-27
 ### Fixed

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -243,6 +243,10 @@ object ExtractorEngine {
     )
   }
 
+  def inMemory(doc: Document): ExtractorEngine = {
+    inMemory(Seq(doc))
+  }
+
   def inMemory(docs: Seq[Document]): ExtractorEngine = {
     inMemory("odinson", docs)
   }

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -243,4 +243,28 @@ object ExtractorEngine {
     )
   }
 
+  def inMemory(docs: Seq[Document]): ExtractorEngine = {
+    inMemory("odinson", docs)
+  }
+
+  def inMemory(path: String, docs: Seq[Document]): ExtractorEngine = {
+    val config = ConfigFactory.load()
+    inMemory(config[Config](path), docs)
+  }
+
+  def inMemory(config: Config, docs: Seq[Document]): ExtractorEngine = {
+    // make a memory index
+    val memWriter = OdinsonIndexWriter.inMemory
+    // add documents to index
+    for (doc <- docs) {
+      val block = memWriter.mkDocumentBlock(doc)
+      memWriter.addDocuments(block)
+    }
+    // finalize index writer
+    memWriter.commit()
+    memWriter.close()
+    // return extractor engine
+    ExtractorEngine.fromDirectory(config, memWriter.directory)
+  }
+
 }

--- a/core/src/test/scala/ai/lum/odinson/TestUtils.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestUtils.scala
@@ -37,7 +37,7 @@ object TestUtils {
     * Constructs an [[ai.lum.odinson.ExtractorEngine]] from a single-doc in-memory index ([[org.apache.lucene.store.RAMDirectory]])
     */
   def mkExtractorEngine(doc: Document): ExtractorEngine = {
-    ExtractorEngine.inMemory(Seq(doc))
+    ExtractorEngine.inMemory(doc)
   }
 
   def mkExtractorEngine(text: String): ExtractorEngine = {

--- a/core/src/test/scala/ai/lum/odinson/TestUtils.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestUtils.scala
@@ -37,12 +37,7 @@ object TestUtils {
     * Constructs an [[ai.lum.odinson.ExtractorEngine]] from a single-doc in-memory index ([[org.apache.lucene.store.RAMDirectory]])
     */
   def mkExtractorEngine(doc: Document): ExtractorEngine = {
-    val memWriter = OdinsonIndexWriter.inMemory
-    val block = memWriter.mkDocumentBlock(doc)
-    memWriter.addDocuments(block)
-    memWriter.commit()
-    memWriter.close()
-    ExtractorEngine.fromDirectory(odinsonConfig, memWriter.directory)
+    ExtractorEngine.inMemory(Seq(doc))
   }
 
   def mkExtractorEngine(text: String): ExtractorEngine = {


### PR DESCRIPTION
Added `ExtractorEngine.inMemory(...)` to help making indexes in memory.