### PR TITLE
write buildinfo to index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Added `ExtractorEngine.inMemory(...)` to help build an index in memory.
+- Added `buildinfo.json` file to the index to store versions and build info.
 ### Changed
 - `extra/AnnotateText` writes compressed json files
 - Reduce number of array allocations

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val core = project
     buildInfoPackage := "ai.lum.odinson",
     buildInfoOptions += BuildInfoOption.ToJson,
     buildInfoKeys := Seq[BuildInfoKey](
-      name, version, scalaVersion, sbtVersion, libraryDependencies, scalacOptions,
+      name, version, scalaVersion, sbtVersion,
       "builtAt" -> {
         val date = new java.util.Date
         val formatter = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")

--- a/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
+++ b/core/src/main/scala/ai/lum/odinson/digraph/Vocabulary.scala
@@ -3,6 +3,7 @@ package ai.lum.odinson.digraph
 import java.io.IOException
 import scala.collection.mutable
 import org.apache.lucene.store.{ Directory, IOContext }
+import ai.lum.odinson.OdinsonIndexWriter
 
 /** This vocabulary is meant for the labels of the edges of the dependency graph.
  *  This object maps a term_id (int) to a symbol (string).
@@ -49,8 +50,6 @@ object Vocabulary {
 
   val sep = "\n"
 
-  val FILE_NAME = "dependencies.txt"
-
   def empty: Vocabulary = {
     new Vocabulary(mutable.ArrayBuffer.empty, mutable.HashMap.empty)
   }
@@ -65,7 +64,7 @@ object Vocabulary {
 
   def fromDirectory(directory: Directory): Vocabulary = try {
     // FIXME: is this the correct instantiation of IOContext?
-    val stream = directory.openInput(Vocabulary.FILE_NAME, new IOContext)
+    val stream = directory.openInput(OdinsonIndexWriter.VOCABULARY_FILENAME, new IOContext)
     Vocabulary.load(stream.readString())
   } catch {
     case e:IOException => Vocabulary.empty

--- a/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
@@ -149,10 +149,6 @@ object Shell extends App {
     println()
     println(s"Scala version: ${BuildInfo.scalaVersion}")
     println(s"Sbt version: ${BuildInfo.sbtVersion}")
-    println(s"Dependencies:")
-    BuildInfo.libraryDependencies.foreach(s => println("  " + s))
-    println(s"Scalac options:")
-    BuildInfo.scalacOptions.foreach(s => println("  " + s))
     println()
   }
 


### PR DESCRIPTION
Add build info to index. This would allow us to know what version of odinson was used to build a particular index.