### PR TITLE
Containerized Odinson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Containerized Odinson
+  - Docker images for [`extra`](https://hub.docker.com/r/lumai/odinson-extras) and the [REST API](https://hub.docker.com/r/lumai/odinson-rest-api) using the [`sbt-native-packager` plugin](https://github.com/sbt/sbt-native-packager).
 - Added `ExtractorEngine.inMemory(...)` to help build an index in memory.
 - Added `disableMatchSelector` to `ExtractorEngine.extractMentions()` to retrieve all spans of tokens that could
   be matched by the query. In other words, it skips the `MatchSelector`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,96 @@ The three apps in extra are:
 - **IndexDocuments**: reads the parsed documents and builds an odinson index
 - **Shell**: this is a shell where you can execute queries (we will replace this with the webapp soon)
 
+## Docker
+
+To build docker images locally, run the following command via [sbt](https://www.scala-sbt.org/1.x/docs/Setup.html):
+
+```bash
+sbt dockerize
+```
+We also publish images to [dockerhub](https://hub.docker.com/orgs/lumai/repositories) (see below for information on our docker images).
+
+#### Docker image for annotating text and indexing Odinson JSON documents
+
+```bash
+docker pull lumai/odinson-extras:latest
+```
+
+See [our repository](https://hub.docker.com/r/lumai/odinson-extras) for other tags.
+
+#### Docker image for running the Odinson REST API
+
+```bash
+docker pull lumai/odinson-rest-api:latest
+```
+
+See [our repository](https://hub.docker.com/r/lumai/odinson-rest-api) for other tags.
+
+### Annotating text
+
+```bash
+docker run \
+  --name="odinson-extras" \
+  -it \
+  --rm \
+  -e "HOME=/app" \
+  -e "JAVA_OPTS=-Dodinson.extra.processorType=CluProcessor" \
+  -v "/path/to/data/odinson:/app/data/odinson" \
+  --entrypoint "bin/annotate-text" \
+  "lumai/odinson-extras:latest"
+```
+
+**NOTE**: Replace `/path/to/data/odinson` with the path to the directory containing a directory called `text` containing the `.txt` files you want to annotate. Compressed OdinsonDocument JSON will be written to a directory called `docs` under whatever you use for `/path/to/data/odinson`.
+
+### Indexing documents
+
+```bash
+docker run \
+  --name="odinson-extras" \
+  -it \
+  --rm \
+  -e "HOME=/app" \
+  -v "/path/to/data/odinson:/app/data/odinson" \
+  --entrypoint "bin/index-documents" \
+  "lumai/odinson-extras:latest"
+```
+
+**NOTE**: Replace `/path/to/data/odinson` with the path to the directory containing `docs`. The index will be written to a directory called `index` under whatever you use for `/path/to/data/odinson`.
+
+### Odinson shell
+
+```bash
+docker run \
+  --name="odinson-extras" \
+  -it \
+  --rm \
+  -e "HOME=/app" \
+  -v "/path/to/data/odinson:/app/data/odinson" \
+  --entrypoint "bin/shell" \
+  "lumai/odinson-extras:latest"
+```
+
+**NOTE**: Replace `/path/to/data/odinson` with the path to the directory containing `index` (created via the `IndexDocuments` runnable).
+
+
+### Running the REST API
+
+```bash
+docker run \
+  --name="odinson-rest-api" \
+  -d \
+  -it \
+  --rm \
+  -e "HOME=/app" \
+  -p "0.0.0.0:9001:9000" \
+  -v "/path/to/data/odinson:/app/data/odinson" \
+  "lumai/odinson-rest-api:latest"
+```
+
+**NOTE**: Replace `/path/to/data/odinson` with the path to the directory containing `docs` and `index` (created via `AnnotateText` and `IndexDocuments` runnables).
+
+Logs can be viewed by running `docker logs -f "odinson-rest-api"`
+
 ## Examples
 
 We have made a few example queries to show how the system works. For this we used a collection of 8,479 scientific papers (or 1,105,737 sentences). Please note that the rapidity of the execution allows a user to dynamically develop these queries in real-time, immediately receiving feedback on the coverage and precision of the patterns at scale.

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -10,6 +10,14 @@ play {
     # The server provider class name
     provider = "play.core.server.AkkaHttpServerProvider"
 
+    # This setting is set in `akka.http.server.parsing.max-content-length`
+    # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
+    max-content-length = infinite
+
+    # This setting is set in `akka.http.server.parsing.max-header-value-length`
+    # and it limits the length of HTTP header values.
+    max-header-value-length = 8k
+    
     http {
       # The HTTP port of the server. Use a value of "disabled" if the server
       # shouldn't bind an HTTP port.
@@ -76,15 +84,6 @@ play {
       # `warn`   : ignore the illegal characters in response header value and log a warning message
       # `ignore` : just ignore the illegal characters in response header value
       illegal-response-header-value-processing-mode = warn
-
-      # This setting is set in `akka.http.server.parsing.max-content-length`
-      # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
-      max-content-length = infinite
-
-      # This setting is set in `akka.http.server.parsing.max-header-value-length`
-      # and it limits the length of HTTP header values.
-      max-header-value-length = 8k
-
 
       # Enables/disables inclusion of an Tls-Session-Info header in parsed
       # messages over Tls transports (i.e., HttpRequest on server side and

--- a/backend/conf/odinson-rest-logger.xml
+++ b/backend/conf/odinson-rest-logger.xml
@@ -3,12 +3,12 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+  <!-- <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
     <encoder>
       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
     </encoder>
-  </appender>
+  </appender> -->
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
@@ -16,9 +16,9 @@
     </encoder>
   </appender>
 
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+  <!-- <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="FILE" />
-  </appender>
+  </appender> -->
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="STDOUT" />

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import ReleaseTransformations._
+import com.typesafe.sbt.packager.docker.DockerChmodType
 
 organization in ThisBuild := "ai.lum"
 
@@ -34,70 +35,46 @@ lazy val extra = project
   .aggregate(core)
   .dependsOn(core)
   .settings(commonSettings)
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
+  .settings(generalDockerSettings)
+  .settings(
+    packageName in Docker := "odinson-extras",
+    //mainClass in Compile := Some("ai.lum.odinson.extra.IndexDocuments"),
+    //dockerRepository := Some("index.docker.io"),
+    //dockerChmodType := DockerChmodType.UserGroupWriteExecute
+    javaOptions in Universal ++= Seq(
+      "-J-Xmx6G"
+    )
+  )
 
 
-lazy val backendAssemblySettings = {
-  mainClass in assembly := Some("play.core.server.ProdServerStart")
-  fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value)
-
-  assemblyMergeStrategy in assembly := {
-    case manifest if manifest.contains("MANIFEST.MF") =>
-      // We don't need manifest files since sbt-assembly will create
-      // one with the given settings
-      MergeStrategy.discard
-    case referenceOverrides if referenceOverrides.contains("reference-overrides.conf") =>
-      // Keep the content for all reference-overrides.conf files
-      MergeStrategy.concat
-    case logback if logback.endsWith("logback.xml")     => MergeStrategy.first
-    case netty if netty.endsWith("io.netty.versions.properties") => MergeStrategy.first
-    case "messages"                                     => MergeStrategy.concat
-    case PathList("META-INF", "terracotta", "public-api-types")  => MergeStrategy.concat
-    case PathList("play", "api", "libs", "ws", xs @ _*) => MergeStrategy.first
-    case PathList("javax", "servlet", xs @ _*)          => MergeStrategy.first
-    case PathList("javax", "transaction", xs @ _*)      => MergeStrategy.first
-    case PathList("javax", "mail", xs @ _*)             => MergeStrategy.first
-    case PathList("javax", "activation", xs @ _*)       => MergeStrategy.first
-    case x =>
-      // For all the other files, use the default sbt-assembly merge strategy
-      val oldStrategy = (assemblyMergeStrategy in assembly).value
-      oldStrategy(x)
-  }
+// Docker settings
+val gitDockerTag = settingKey[String]("Git commit-based tag for docker")
+ThisBuild / gitDockerTag := {
+  val shortHash: String = git.gitHeadCommit.value.get.take(7)  
+  val uncommittedChanges: Boolean = (git.gitUncommittedChanges).value
+  s"""${shortHash}${if (uncommittedChanges) "-DIRTY" else ""}"""
 }
 
-lazy val backendDockerSettings = {
+lazy val generalDockerSettings = {
   Seq(
-    dockerfile in docker := {
-      val targetDir = "/app"
-      // the assembly task generates a fat jar
-      val artifact: File = assembly.value
-      val artifactTargetPath = s"$targetDir/${artifact.name}"
-      // val productionConf = "production.conf"
-      new Dockerfile {
-        from("openjdk:11")
-        add(artifact, artifactTargetPath)
-        // copy(new File(productionConf), file(s"$targetDir/$productionConf"))
-        entryPoint("java", "-Dpidfile.path=/dev/null", //s"-Dconfig.file=$targetDir/$productionConf",
-          "-jar", artifactTargetPath)
-      }
-    },
-    imageNames in docker := {
-      val commit = git.gitHeadCommit.value.getOrElse(s"v${version.value}")
-      Seq(
-        // sets the latest tag
-        ImageName(s"${organization.value}/${name.value}:latest"),
-        // use git hash
-        ImageName(s"${organization.value}/${name.value}:${commit}"),
-        // sets a name with a tag that contains the project version
-        ImageName(
-          namespace = Some(organization.value),
-          repository = name.value,
-          tag = Some("v" + version.value)
-        )
-      )
-    }
+    parallelExecution in ThisBuild := false,
+    // see https://www.scala-sbt.org/sbt-native-packager/formats/docker.html
+    dockerUsername := Some("lumai"),
+    dockerAliases ++= Seq(
+      dockerAlias.value.withTag(Option("latest")),
+      dockerAlias.value.withTag(Option(gitDockerTag.value))
+    ),
+    maintainer in Docker := "Gus Hahn-Powell <ghp@lum.ai>",
+    // "openjdk:11-jre-alpine"
+    dockerBaseImage := "openjdk:11",
+    javaOptions in Universal ++= Seq(
+      "-Dodinson.dataDir=/app/data/odinson"
+    )
   )
 }
 
+// REST API
 lazy val backend = project
   .aggregate(core)
   .dependsOn(core % "test->test;compile->compile")
@@ -128,12 +105,23 @@ lazy val backend = project
     PlayKeys.devSettings += "play.server.http.address" -> "0.0.0.0",
     PlayKeys.devSettings += "play.server.http.idleTimeout" -> "infinite"
   )
-  .settings(backendAssemblySettings)
-  .settings(backendDockerSettings)
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
+  .settings(generalDockerSettings)
+  .settings(
+    packageName in Docker := "odinson-rest-api",
+    mainClass in Compile := Some("play.core.server.ProdServerStart"),
+    //dockerRepository := Some("index.docker.io"),
+    dockerExposedPorts in Docker := Seq(9000),
+    //dockerChmodType := DockerChmodType.UserGroupWriteExecute
+    javaOptions in Universal ++= Seq(
+      "-J-Xmx4G",
+      // avoid writing a PID file
+      "-Dplay.server.pidfile.path=/dev/null"
+    )
+  )
 
 
-
-// release steps
+// Release steps
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -148,7 +136,6 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
-
 
 // Publishing settings
 
@@ -175,4 +162,5 @@ developers in ThisBuild := List(
 
 
 // tasks
-addCommandAlias("dockerizeRestApi", ";clean;compile;test;backend/docker")
+addCommandAlias("dockerize", ";clean;compile;test;docker:publishLocal")
+addCommandAlias("dockerizeAndPublish", ";clean;compile;test;docker:publish")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import ReleaseTransformations._
 import com.typesafe.sbt.packager.docker.DockerChmodType
 
+
 organization in ThisBuild := "ai.lum"
 
 scalaVersion in ThisBuild := "2.12.10"
@@ -84,13 +85,14 @@ lazy val backend = project
   .settings(
     name := "odinson-rest-api",
     libraryDependencies ++= {
-      val akkaV = "2.5.4"
+      val akkaV = "2.6.6"
       Seq(
         guice,
         jdbc,
         ehcache,
         ws,
-        "org.scalatestplus.play"  %% "scalatestplus-play" % "3.0.0" % Test,
+        "org.scalatestplus.play"  %% "scalatestplus-play" % "5.0.0" % Test,
+        "com.typesafe.akka" %% "akka-actor-typed" % akkaV,
         "com.typesafe.akka" %% "akka-protobuf" % akkaV,
         "com.typesafe.akka" %% "akka-actor" % akkaV,
         "com.typesafe.akka" %% "akka-slf4j" % akkaV,
@@ -112,11 +114,11 @@ lazy val backend = project
     mainClass in Compile := Some("play.core.server.ProdServerStart"),
     //dockerRepository := Some("index.docker.io"),
     dockerExposedPorts in Docker := Seq(9000),
-    //dockerChmodType := DockerChmodType.UserGroupWriteExecute
     javaOptions in Universal ++= Seq(
       "-J-Xmx4G",
       // avoid writing a PID file
-      "-Dplay.server.pidfile.path=/dev/null"
+      "-Dplay.server.pidfile.path=/dev/null",
+      "-Dlogger.resource=odinson-rest-logger.xml"
     )
   )
 

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -21,8 +21,8 @@ odinson.extra {
     resources = extra/src/main/resources/
     # processor to use for AnnotateText
     # choices: FastNLPProcessor, CluProcessor, BioCluProcessor
-    processorType     = "FastNLPProcessor"
-    # processorType    = "CluProcessor"
+    processorType    = "CluProcessor"
+    #processorType     = "FastNLPProcessor"
     # processorType     = "BioCluProcessor"
     rulesFile = ${odinson.extra.resources}/example/rules.yml
     outputFile = example_extractions.jsonl

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 // REST API 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 // REST API 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.3")


### PR DESCRIPTION
Using the `sbt-native-packager`, we now have docker images for `extra` ([`lumai/odinson-extras`](https://hub.docker.com/repository/docker/lumai/odinson-extras)) and the REST API ([`lumai/odinson-rest-api`](https://hub.docker.com/repository/docker/lumai/odinson-extras)).

The README at the project root includes a section with instructions for building images and running apps and services via docker.