### PR TITLE
refactoring to simplfy method calls

### DIFF
--- a/core/src/main/scala/ai/lum/odinson/DefaultMentionFactory.scala
+++ b/core/src/main/scala/ai/lum/odinson/DefaultMentionFactory.scala
@@ -2,12 +2,18 @@ package ai.lum.odinson
 
 class DefaultMentionFactory extends MentionFactory {
 
-  def newMention(odinsonMatch: OdinsonMatch,
+  def newMention(
+    odinsonMatch: OdinsonMatch,
     label: Option[String],
     luceneDocId: Int,
     luceneSegmentDocId: Int,
     luceneSegmentDocBase: Int,
     docId: String,
     sentenceId: String,
-    foundBy: String): Mention = new Mention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy)
+    foundBy: String,
+    arguments: Map[String, Array[Mention]],
+  ): Mention = {
+    new Mention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy, arguments)
+  }
+
 }

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -148,7 +148,7 @@ class ExtractorEngine(
   }
 
   def getArgument(mention: Mention, name: String): String = {
-    getString(mention.luceneDocId, mention.arguments(mentionFactory)(name).head.odinsonMatch)
+    getString(mention.luceneDocId, mention.arguments(name).head.odinsonMatch)
   }
 
   def getTokens(m: Mention): Array[String] = {

--- a/core/src/main/scala/ai/lum/odinson/Mention.scala
+++ b/core/src/main/scala/ai/lum/odinson/Mention.scala
@@ -1,7 +1,5 @@
 package ai.lum.odinson
 
-import ai.lum.common.Interval
-
 class Mention(
   val odinsonMatch: OdinsonMatch,
   val label: Option[String],
@@ -10,36 +8,12 @@ class Mention(
   val luceneSegmentDocBase: Int,
   val docId: String,
   val sentenceId: String,
-  val foundBy: String
+  val foundBy: String,
+  val arguments: Map[String, Array[Mention]],
 ) {
 
-  /** A map from argument name to a sequence of matches.
-    *
-    * The value of the map is a sequence because there are events
-    * that can have several arguments with the same name.
-    * For example, in the biodomain, Binding may have several themes.
-    */
-  def arguments(mentionFactory: MentionFactory /*= new DefaultMentionFactory*/): Map[String, Array[Mention]] = {
-    odinsonMatch
-      .namedCaptures
-      .groupBy(_.name)
-      .transform { (k,v) =>
-        v.map { c =>
-          mentionFactory.newMention(
-            c.capturedMatch,
-            c.label,
-            luceneDocId,
-            luceneSegmentDocId,
-            luceneSegmentDocBase,
-            docId,
-            sentenceId,
-            // we mark the captures as matched by the same rule as the whole match
-            foundBy)
-        }
-      }
-  }
-
-  def copy(mentionFactory: MentionFactory /*= new DefaultMentionFactory*/,
+  def copy(
+    mentionFactory: MentionFactory /*= new DefaultMentionFactory*/,
     odinsonMatch: OdinsonMatch = this.odinsonMatch,
     label: Option[String] = this.label,
     luceneDocId: Int = this.luceneDocId,
@@ -47,7 +21,9 @@ class Mention(
     luceneSegmentDocBase: Int = this.luceneSegmentDocBase,
     docId: String = this.docId,
     sentenceId: String = this.sentenceId,
-    foundBy: String = this.foundBy): Mention = {
-      mentionFactory.newMention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy)
+    foundBy: String = this.foundBy,
+    arguments: Map[String, Array[Mention]] = this.arguments
+  ): Mention = {
+      mentionFactory.newMention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy, arguments)
   }
 }

--- a/core/src/main/scala/ai/lum/odinson/MentionFactory.scala
+++ b/core/src/main/scala/ai/lum/odinson/MentionFactory.scala
@@ -2,12 +2,71 @@ package ai.lum.odinson
 
 trait MentionFactory {
 
-  def newMention(odinsonMatch: OdinsonMatch,
+  // If you are implementing a custom MentionFactory, this is the primary method
+  // you need to implement.
+  def newMention(
+    odinsonMatch: OdinsonMatch,
     label: Option[String],
     luceneDocId: Int,
     luceneSegmentDocId: Int,
     luceneSegmentDocBase: Int,
     docId: String,
     sentenceId: String,
-    foundBy: String): Mention
+    foundBy: String,
+    arguments: Map[String, Array[Mention]],
+  ): Mention
+
+  def newMention(
+    odinsonMatch: OdinsonMatch,
+    label: Option[String],
+    luceneDocId: Int,
+    luceneSegmentDocId: Int,
+    luceneSegmentDocBase: Int,
+    docId: String,
+    sentenceId: String,
+    foundBy: String
+  ): Mention = {
+    val arguments = mkArguments(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy)
+    newMention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, docId, sentenceId, foundBy, arguments)
+  }
+
+  /** A map from argument name to a sequence of matches.
+    *
+    * The value of the map is a sequence because there are events
+    * that can have several arguments with the same name.
+    * For example, in the biodomain, Binding may have several themes.
+    */
+  def mkArguments(
+    odinsonMatch: OdinsonMatch,
+    label: Option[String],
+    luceneDocId: Int,
+    luceneSegmentDocId: Int,
+    luceneSegmentDocBase: Int,
+    docId: String,
+    sentenceId: String,
+    foundBy: String,
+  ): Map[String, Array[Mention]] = {
+    odinsonMatch
+      .namedCaptures
+      // get all the matches for each name
+      .groupBy(_.name)
+      .transform { (name, matches) =>
+        // Make a mention from each match in the named capture
+        matches.map { m =>
+          newMention(
+            m.capturedMatch,
+            m.label,
+            luceneDocId,
+            luceneSegmentDocId,
+            luceneSegmentDocBase,
+            docId,
+            sentenceId,
+            // we mark the captures as matched by the same rule as the whole match
+            // todo: FoundBy handler
+            // todo: add foundBy info to state somehow
+            foundBy)
+        }
+      }
+  }
+
 }


### PR DESCRIPTION
First -- I love the idea of the MentionFactory, I think this will really simply things in external projects!
I am doing this as a PR on your PR branch bc I think you do it that way in Eidos :)

@kwalcock  -- met with @marcovzla and tried to refactor this a little to make it so that Mention doesn't need to care about what MentionFactory you're using when retrieving the arguments.
Did this by (a) making the args a val, not a def, and (b) teaching the MentionFactory trait how to make Mention arguments.  Likely this implementation will suffice most external needs, and won't often need to be overridden, but of course it can be.

If you like this, please merge into your branch and we can then merge into master?