### PR TITLE
Remove \r from """ strings where it matters

### DIFF
--- a/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonDocument.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonDocument.scala
@@ -54,7 +54,7 @@ class TestOdinsonDocument extends BaseSpec {
         |        "I-NP",
         |        "O"
         |    ]
-        |}""".stripMargin
+        |}""".stripMargin.replace("\r", "")
     //
     val tokenField = TokensField.fromJson(field)
     // check if the name is being parsed correct
@@ -134,7 +134,7 @@ class TestOdinsonDocument extends BaseSpec {
     |            ]
     |        }
     |    ]
-    |}""".stripMargin
+    |}""".stripMargin.replace("\r", "")
     // test pretty
     sentenceObj.toPrettyJson shouldEqual (prettySentence)
   }


### PR DESCRIPTION
Tests do not pass under Windows without this.  Git by default ends these lines with \r\n.  We should allows others to use the defaults and compensate in the code.