### PR TITLE
Fix warning when publishing documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,4 @@
 title: "odinson"
 remote_theme: pmarsceill/just-the-docs
-theme: "just-the-docs"
 color_scheme: odinson
 search_enabled: true


### PR DESCRIPTION
Closes #159

The line is not needed since the theme is being pulled from remote.