### PR TITLE
REST API no longer depends on extra

### DIFF
--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -400,13 +400,10 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
   }
   
   def mkJson(mention: Mention): Json.JsValueWrapper = {
-    val doc = extractorEngine.indexSearcher.doc(mention.luceneDocId)
-    val tvs = extractorEngine.indexReader.getTermVectors(mention.luceneDocId)
-    val sentenceText = doc.getField(WORD_TOKEN_FIELD).stringValue
-    val ts = TokenSources.getTokenStream(WORD_TOKEN_FIELD, tvs, sentenceText, new WhitespaceAnalyzer, -1)
-    val tokens = TokenStreamUtils.getTokens(ts)
-
-      // odinsonMatch: OdinsonMatch,
+    //val doc: LuceneDocument = extractorEngine.indexSearcher.doc(mention.luceneDocId)
+    // We want **all** tokens for the sentence
+    val tokens = extractorEngine.getTokens(mention.luceneDocId, WORD_TOKEN_FIELD)
+    // odinsonMatch: OdinsonMatch,
     Json.obj(
       "sentenceId"    -> mention.luceneDocId,
       // "score"         -> odinsonScoreDoc.score,
@@ -420,11 +417,9 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
   }
 
   def mkJson(odinsonScoreDoc: OdinsonScoreDoc): Json.JsValueWrapper = {
-    val doc = extractorEngine.indexSearcher.doc(odinsonScoreDoc.doc)
-    val tvs = extractorEngine.indexReader.getTermVectors(odinsonScoreDoc.doc)
-    val sentenceText = doc.getField(WORD_TOKEN_FIELD).stringValue
-    val ts = TokenSources.getTokenStream(WORD_TOKEN_FIELD, tvs, sentenceText, new WhitespaceAnalyzer, -1)
-    val tokens = TokenStreamUtils.getTokens(ts)
+    //val doc = extractorEngine.indexSearcher.doc(odinsonScoreDoc.doc)
+    // we want **all** tokens for the sentence
+    val tokens = extractorEngine.getTokens(odinsonScoreDoc.doc, WORD_TOKEN_FIELD)
     Json.obj(
       "sentenceId"    -> odinsonScoreDoc.doc,
       "score"         -> odinsonScoreDoc.score,

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,6 @@ lazy val generalDockerSettings = {
 lazy val backend = project
   .aggregate(core)
   .dependsOn(core % "test->test;compile->compile")
-  .dependsOn(extra)
   .settings(commonSettings)
   .enablePlugins(PlayScala)
   .settings(

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -194,19 +194,19 @@ class ExtractorEngine(
     odinResults
   }
 
-  def getString(docID: Int, m: OdinsonMatch): String = {
-    getTokens(docID, m).mkString(" ")
+  def getStringForSpan(docID: Int, m: OdinsonMatch): String = {
+    getTokensForSpan(docID, m).mkString(" ")
   }
 
   def getArgument(mention: Mention, name: String): String = {
-    getString(mention.luceneDocId, mention.arguments(name).head.odinsonMatch)
+    getStringForSpan(mention.luceneDocId, mention.arguments(name).head.odinsonMatch)
   }
 
-  def getTokens(m: Mention): Array[String] = {
-    getTokens(m.luceneDocId, m.odinsonMatch)
+  def getTokensForSpan(m: Mention): Array[String] = {
+    getTokensForSpan(m.luceneDocId, m.odinsonMatch)
   }
 
-  def getTokens(docID: Int, m: OdinsonMatch): Array[String] = {
+  def getTokensForSpan(docID: Int, m: OdinsonMatch): Array[String] = {
     getTokens(docID, displayField).slice(m.start, m.end)
   }
 

--- a/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
@@ -53,7 +53,7 @@ class TestEventTriggers extends EventSpec {
     
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
   }
@@ -69,7 +69,7 @@ class TestEventTriggers extends EventSpec {
     
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
   }
@@ -85,7 +85,7 @@ class TestEventTriggers extends EventSpec {
     
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
   }
@@ -101,8 +101,8 @@ class TestEventTriggers extends EventSpec {
 
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("wild animals such", "wild animals such", "wild animals such", "wild cloven-footed animals such", "wild cloven-footed animals such")
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     triggers should contain theSameElementsInOrderAs expectedTriggers
@@ -120,8 +120,8 @@ class TestEventTriggers extends EventSpec {
     
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild", "any wild")
     val expectedResults = List("animals", "animals")
     triggers should contain theSameElementsInOrderAs expectedTriggers
@@ -138,8 +138,8 @@ class TestEventTriggers extends EventSpec {
     )
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild animals such as hedgehogs , coypu , and any wild cloven-footed animals such as deer and zoo animals")
     val expectedResults = List("elephants")
     triggers should contain theSameElementsInOrderAs expectedTriggers
@@ -156,8 +156,8 @@ class TestEventTriggers extends EventSpec {
     )
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors, allowTriggerOverlaps = true)
-    val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers: List[String] = (1 to 6).map(
       (m) =>  "Some wild animals such as hedgehogs , coypu , and any wild cloven-footed animals such as deer and zoo animals"
     ).toList
@@ -177,8 +177,8 @@ class TestEventTriggers extends EventSpec {
     )
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild animals", "Some wild animals", "Some wild animals")
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals")
     triggers should contain theSameElementsInOrderAs expectedTriggers
@@ -194,7 +194,7 @@ class TestEventTriggers extends EventSpec {
     )
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")
     animals should contain theSameElementsInOrderAs expectedResults
   }
@@ -210,7 +210,7 @@ class TestEventTriggers extends EventSpec {
     
     val extractors = ee.ruleReader.compileRuleFile(rules)
     val mentions = ee.extractMentions(extractors)
-    val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
+    val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")
     animals should contain theSameElementsInOrderAs expectedResults
   }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -70,7 +70,7 @@ class TestOdinsonIndexWriter extends BaseSpec {
 
     val matches = results.scoreDocs.head.matches
     val docId = results.scoreDocs.head.doc
-    val foundStrings = matches.map(m => ee.getString(docId, m))
+    val foundStrings = matches.map(m => ee.getStringForSpan(docId, m))
 
     foundStrings shouldEqual expectedMatches
   }

--- a/core/src/test/scala/ai/lum/odinson/traversals/TestTraversals.scala
+++ b/core/src/test/scala/ai/lum/odinson/traversals/TestTraversals.scala
@@ -24,8 +24,8 @@ class TestTraversals extends BaseSpec {
     results.scoreDocs.head.matches should have size 2
     val doc = results.scoreDocs.head.doc
     val Array(m1, m2) = results.scoreDocs.head.matches
-    eeAlien.getString(doc, m1) should equal ("horses")
-    eeAlien.getString(doc, m2) should equal ("cattle")
+    eeAlien.getStringForSpan(doc, m1) should equal ("horses")
+    eeAlien.getStringForSpan(doc, m2) should equal ("cattle")
   }
 
   it should "support parentheses surrounding graph traversals AND surface patterns" in {
@@ -36,8 +36,8 @@ class TestTraversals extends BaseSpec {
     results.scoreDocs.head.matches should have size 2
     val doc = results.scoreDocs.head.doc
     val Array(m1, m2) = results.scoreDocs.head.matches
-    eeAlien.getString(doc, m1) should equal ("horses")
-    eeAlien.getString(doc, m2) should equal ("cattle")
+    eeAlien.getStringForSpan(doc, m1) should equal ("horses")
+    eeAlien.getStringForSpan(doc, m2) should equal ("cattle")
   }
 
   // A little helper method to reduce code duplication for the following tests
@@ -49,7 +49,7 @@ class TestTraversals extends BaseSpec {
     val matches = results.scoreDocs.head.matches
     matches should have size expectedMatches.length
     val doc = results.scoreDocs.head.doc
-    val foundStrings = matches.map(m => eeHedgehogs.getString(doc, m))
+    val foundStrings = matches.map(m => eeHedgehogs.getStringForSpan(doc, m))
     foundStrings shouldEqual expectedMatches
   }
 
@@ -83,7 +83,7 @@ class TestTraversals extends BaseSpec {
     results.totalHits should equal (1)
     val matches = results.scoreDocs.head.matches
     val doc = results.scoreDocs.head.doc
-    val foundStrings = matches.map(m => eeSpoon.getString(doc, m))
+    val foundStrings = matches.map(m => eeSpoon.getStringForSpan(doc, m))
     foundStrings shouldEqual expectedMatches
   }
 

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -1,7 +1,6 @@
 # directory to store processors documents
 
-odinson.dataDir = ".."
-
+#odinson.dataDir = ".."
 odinson.procDir = ${odinson.dataDir}/proc
 
 odinson.shell {
@@ -29,9 +28,6 @@ odinson.extra {
     rulesFile = ${odinson.extra.resources}/example/rules.yml
     outputFile = example_extractions.jsonl
 }
-
-odinson.textDir = "../txt" // txt format
-odinson.docsDir = "../docs" // json format
 
 odinson.index {
     # the raw token

--- a/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
@@ -82,7 +82,7 @@ object Example extends App with LazyLogging{
       nc <- namedCaptures
       argName = nc.name
       capturedMatch = nc.capturedMatch
-      tokens = extractorEngine.getTokens(luceneDocID, capturedMatch).toSeq
+      tokens = extractorEngine.getTokensForSpan(luceneDocID, capturedMatch).toSeq
     } yield ArgInfo(argName, tokens)
   }
 


### PR DESCRIPTION
These changes are motivated by a desire to better synchronize solutions in `core` and `backend`.

## Summary of changes
- `getTokens` vs `getTokensForSpan`: differentiate between retrieving **all** tokens for a sentence (doc) vs just those included in a matched span.  Previously, `getTokens` was conflating these two needs. 
- By relying on the `getTokens` method in the `ExtractorEngine`, `backend` no longer needs to depend on `extra` and the validation fix introduced by #173 works for the REST API.
- The config for `extra` seemed inconsistent with `core`, so I've commented the change to `dataDir` in the `application.conf` in `extra`.