### PR TITLE
grammar imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `buildinfo.json` file to the index to store versions and build info.
 - Added ability to express rule vars as lists, in addition to the current string representation.
 - Put indexing docs in a method to be used by external projects. ([#90](https://github.com/lum-ai/odinson/pull/90))
-- Started documention at [http://gh.lum.ai/odinson/](http://gh.lum.ai/odinson/) ([#97](https://github.com/lum-ai/odinson/pull/97))
+- Started documentation at [http://gh.lum.ai/odinson/](http://gh.lum.ai/odinson/) ([#97](https://github.com/lum-ai/odinson/pull/97))
 ### Changed
 - Different organization for tests. Now every test extends a `BaseSpec` class and there are 6 categories of tests.
 - Turn `State` into a trait with very basic `SqlState` and even more basic `MemoryState` and placeholder `FileState` implementations by [@kwalcock](https://github.com/kwalcock)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Grammar files now support imports, from both respurces and filesystem; absolute and relative paths ([#175](https://github.com/lum-ai/odinson/pull/175)).
 - Validation of tokens to ensure they are compatible with Lucene ([#170](https://github.com/lum-ai/odinson/pull/170))
 - Add priority as String to `Rule` and as `Priority` to `Extractor`
 - Add `MentionFactory` to be optionally passed during construction of the `ExtractorEngine` so that custom `Mentions`

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -1,5 +1,6 @@
 package ai.lum.odinson
 
+import java.io.File
 import java.nio.file.Path
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
@@ -90,12 +91,37 @@ class ExtractorEngine(
     docs.head
   }
 
-  def compileRules(rules: String): Seq[Extractor] = {
-    compileRules(rules, Map.empty)
+  // Access methods
+  def compileRuleString(rules: String): Seq[Extractor] = {
+    compileRuleString(rules, Map.empty[String, String])
   }
 
-  def compileRules(rules: String, variables: Map[String, String]): Seq[Extractor] = {
-    ruleReader.compileRuleFile(rules, variables)
+  def compileRuleString(rules: String, variables: Map[String, String]): Seq[Extractor] = {
+    ruleReader.compileRuleString(rules, variables)
+  }
+
+  def compileRuleFile(ruleFile: File): Seq[Extractor] = {
+    compileRuleFile(ruleFile, Map.empty[String, String])
+  }
+
+  def compileRuleFile(ruleFile: File, variables: Map[String, String]): Seq[Extractor] = {
+    ruleReader.compileRuleFile(ruleFile, variables)
+  }
+
+  def compileRuleFile(rulePath: String): Seq[Extractor] = {
+    compileRuleFile(rulePath, Map.empty[String, String])
+  }
+
+  def compileRuleFile(rulePath: String, variables: Map[String, String]): Seq[Extractor] = {
+    ruleReader.compileRuleFile(rulePath, variables)
+  }
+
+  def compileRuleResource(rulePath: String): Seq[Extractor] = {
+    compileRuleResource(rulePath, Map.empty[String, String])
+  }
+
+  def compileRuleResource(rulePath: String, variables: Map[String, String]): Seq[Extractor] = {
+    ruleReader.compileRuleResource(rulePath, variables)
   }
 
   /** Apply the extractors and return all results */

--- a/core/src/main/scala/ai/lum/odinson/RuleReader.scala
+++ b/core/src/main/scala/ai/lum/odinson/RuleReader.scala
@@ -230,7 +230,9 @@ class RuleReader(val compiler: QueryCompiler) {
   def makeOrImportRules(data: Any, source: SituatedStream, parentVars: Map[String, String]): Seq[RuleFile] = {
     data match {
       case imported: JMap[String, Any] if imported.asScala.contains("import") =>
-        assert(source.from != RuleSources.string, "Imports are not supported for string-only rules")
+        if (source.from == RuleSources.string) {
+          throw new RuntimeException("Imports are not supported for string-only rules")
+        }
         // import rules from a file and return them
         val importVars = mkVariables(imported.asScala.toMap)
         importRules(imported.asScala.toMap, source, parentVars ++ importVars)

--- a/core/src/main/scala/ai/lum/odinson/RuleReader.scala
+++ b/core/src/main/scala/ai/lum/odinson/RuleReader.scala
@@ -129,7 +129,6 @@ class RuleReader(val compiler: QueryCompiler) {
   def parseRuleFile(input: SituatedStream, parentVars: Map[String, String]): Seq[RuleFile] = {
     val yaml = new Yaml(new Constructor(classOf[JMap[String, Any]]))
     val master = using(input.stream) { stream =>
-      println(input.canonicalPath)
       yaml.load(stream).asInstanceOf[JMap[String, Any]].asScala.toMap
     }
     val localVariables = mkVariables(master) ++ parentVars

--- a/core/src/main/scala/ai/lum/odinson/RuleReader.scala
+++ b/core/src/main/scala/ai/lum/odinson/RuleReader.scala
@@ -1,12 +1,16 @@
 package ai.lum.odinson
 
-import java.util.{ Collection, Map => JMap }
+import java.io.File
+import java.util.{Collection, Map => JMap}
+
+import ai.lum.common.TryWithResources.using
+
 import scala.collection.JavaConverters._
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
 import ai.lum.odinson.compiler.QueryCompiler
 import ai.lum.odinson.lucene.search.OdinsonQuery
-import ai.lum.odinson.utils.VariableSubstitutor
+import ai.lum.odinson.utils.{RuleSources, SituatedStream, VariableSubstitutor}
 
 /** A RuleFile is the result of parsing a yaml file.
  *  At this point variables haven't been replaced
@@ -39,31 +43,100 @@ case class Extractor(
   query: OdinsonQuery,
 )
 
+
 class RuleReader(val compiler: QueryCompiler) {
 
-  /** gets the contents of a rule file and returns a sequence of extractors ready to be used */
-  def compileRuleFile(input: String): Seq[Extractor] = {
-    compileRuleFile(input, Map.empty)
+  /** gets a rule stream and returns a sequence of extractors ready to be used */
+  def compileRuleStream(input: SituatedStream): Seq[Extractor] = {
+    compileRuleStream(input, Map.empty[String, String])
   }
 
-  /** Gets the contents of a rule file as well as a map of variables.
+  /** Gets a rule stream as well as a map of variables.
+    *  Returns a sequence of extractors ready to be used.
+    *  The variables passed as an argument will override the variables declared in the file.
+    */
+  def compileRuleStream(input: SituatedStream, variables: Map[String, String]): Seq[Extractor] = {
+    val ruleFiles = parseRuleFile(input)
+    mkExtractorsFromRuleFiles(ruleFiles, variables)
+  }
+
+  /**
+    * gets the path to a rule file and returns a sequence of extractors ready to be used
+    * @param input String path to the rule file
+    * @return extractors
+    */
+  def compileRuleFile(input: String): Seq[Extractor] = {
+    compileRuleFile(input, Map.empty[String, String])
+  }
+
+  /** Gets the path to a rule file as well as a map of variables.
    *  Returns a sequence of extractors ready to be used.
    *  The variables passed as an argument will override the variables declared in the file.
    */
   def compileRuleFile(input: String, variables: Map[String, String]): Seq[Extractor] = {
-    mkExtractors(parseRuleFile(input), variables)
+    compileRuleFile(new File(input), variables)
+  }
+
+  /** gets a rule File object and returns a sequence of extractors ready to be used */
+  def compileRuleFile(input: File): Seq[Extractor] = {
+    compileRuleFile(input, Map.empty[String, String])
+  }
+
+  /** Gets a rule File object as well as a map of variables.
+    *  Returns a sequence of extractors ready to be used.
+    *  The variables passed as an argument will override the variables declared in the file.
+    */
+  def compileRuleFile(input: File, variables: Map[String, String]): Seq[Extractor] = {
+    compileRuleStream(SituatedStream.fromFile(input.getCanonicalPath), variables)
+  }
+
+  /**
+    * Gets the path to a rule file in the jar resources as well as a map of variables.
+    * Returns a sequence of extractors ready to be used
+    */
+  def compileRuleResource(rulePath: String): Seq[Extractor] = {
+    compileRuleResource(rulePath, Map.empty[String, String])
+  }
+
+  /**
+    * Gets the path to a rule file in the jar resources as well as a map of variables.
+    * Returns a sequence of extractors ready to be used
+    */
+  def compileRuleResource(rulePath: String, variables: Map[String, String]): Seq[Extractor] = {
+    compileRuleStream(SituatedStream.fromResource(rulePath), variables)
+  }
+
+  /**
+    * Gets the actual rules content as a string.
+    * Returns a sequence of extractors ready to be used
+    */
+  def compileRuleString(rules: String): Seq[Extractor] = {
+    compileRuleString(rules, Map.empty[String, String])
+  }
+
+  /**
+    * Gets the actual rules content as a string.
+    * Returns a sequence of extractors ready to be used
+    */
+  def compileRuleString(rules: String, variables: Map[String, String]): Seq[Extractor] = {
+    compileRuleStream(SituatedStream.fromString(rules), variables)
   }
 
   /** Parses the content of the rule file and returns a RuleFile object
    *  that contains the parsed rules and the variables declared in the file.
    *  Note that variable replacement hasn't happened yet.
    */
-  def parseRuleFile(input: String): RuleFile = {
+  def parseRuleFile(input: SituatedStream): Seq[RuleFile] = {
     val yaml = new Yaml(new Constructor(classOf[JMap[String, Any]]))
-    val master = yaml.load(input).asInstanceOf[JMap[String, Any]].asScala.toMap
+    val master = using(input.stream) { stream =>
+      yaml.load(stream).asInstanceOf[JMap[String, Any]].asScala.toMap
+    }
     val variables = mkVariables(master)
-    val rules = mkRules(master)
-    RuleFile(rules, variables)
+    mkRules(master, input, variables)
+  }
+
+  def mkExtractorsFromRuleFiles(rfs: Seq[RuleFile], variables: Map[String, String]): Seq[Extractor] = {
+    rfs.flatMap(r => mkExtractors(r, variables))
   }
 
   /** gets a RuleFile and returns a sequence of extractors */
@@ -98,11 +171,11 @@ class RuleReader(val compiler: QueryCompiler) {
     // so we need to pass them through the variable substitutor
     val name = varsub(rule.name)
     val label = rule.label.map(varsub.apply)
-    val ruletype = varsub(rule.ruletype)
+    val ruleType = varsub(rule.ruletype)
     val priority = Priority(varsub(rule.priority))
     val pattern = varsub(rule.pattern)
     // compile query
-    val query = ruletype match {
+    val query = ruleType match {
       case "basic" => compiler.compile(pattern)
       case "event" => compiler.compileEventQuery(pattern)
       case t => sys.error(s"invalid rule type '$t'")
@@ -122,7 +195,7 @@ class RuleReader(val compiler: QueryCompiler) {
           .asScala
           .map { case (k, v) => k.toString -> processVar(v) }
           .toMap
-      case _ => sys.error("invalid variables data")
+      case _ => sys.error(s"invalid variables data: ${data}")
     }
   }
 
@@ -142,12 +215,41 @@ class RuleReader(val compiler: QueryCompiler) {
     }
   }
 
-  private def mkRules(data: Map[String, Any]): Seq[Rule] = {
+  private def mkRules(data: Map[String, Any], source: SituatedStream, vars: Map[String, String]): Seq[RuleFile] = {
     data.get("rules") match {
       case None => Seq.empty
-      case Some(rules: Collection[_]) => rules.asScala.map(mkRule).toSeq
+      case Some(rules: Collection[_]) =>
+        rules.asScala.toSeq.flatMap { r =>
+          makeOrImportRules(r, source, vars)
+        }
       case _ => sys.error("invalid rules data")
     }
+  }
+
+
+  def makeOrImportRules(data: Any, source: SituatedStream, parentVars: Map[String, String]): Seq[RuleFile] = {
+    data match {
+      case imported: JMap[String, Any] if imported.asScala.contains("import") =>
+        assert(source.from != RuleSources.string, "Imports are not supported for string-only rules")
+        // import rules from a file and return them
+        val importVars = mkVariables(imported.asScala.toMap)
+        importRules(imported.asScala.toMap, source, parentVars ++ importVars)
+        // RuleFile (seq[Rule], vars)
+      case _ => Seq(RuleFile(Seq(mkRule(data)), parentVars))
+    }
+  }
+
+  private def importRules(
+    data: Map[String, Any],
+    source: SituatedStream,
+    vars: Map[String, String],
+  ): Seq[RuleFile] = {
+    // get the current working directory, with ending separator
+    val relativePath = data("import").toString
+    // handle substitutions in path name
+    val resolved = new VariableSubstitutor(vars).apply(relativePath)
+    val importStream = source.relativePathStream(resolved)
+    parseRuleFile(importStream)
   }
 
   private def mkRule(data: Any): Rule = {
@@ -163,11 +265,11 @@ class RuleReader(val compiler: QueryCompiler) {
         // read fields
         val name = getRequiredField("name")
         val label = getField("label")
-        val ruletype = getRequiredField("type")
+        val ruleType = getRequiredField("type")
         val priority = fields.getOrElse("priority", "1").toString
         val pattern = getRequiredField("pattern")
         // return rule
-        Rule(name, label, ruletype, priority, pattern)
+        Rule(name, label, ruleType, priority, pattern)
       case _ => sys.error("invalid rule data")
     }
   }

--- a/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
@@ -24,7 +24,11 @@ case class SituatedStream(stream: InputStream, canonicalPath: String, from: Rule
     from match {
       case RuleSources.resource =>
         var prevPath = canonicalPath
-        if (!prevPath.endsWith("/")) prevPath += "/"
+        if (!prevPath.endsWith("/")) {
+          val lastSep = prevPath.lastIndexOf("/")
+          prevPath = prevPath.slice(0, lastSep)
+          prevPath += "/"
+        }
         prevPath + path
       case RuleSources.file => new File(canonicalPath, path).getCanonicalPath
       case RuleSources.string => throw new RuntimeException("Strings don't support imports and relative paths")

--- a/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
@@ -1,0 +1,64 @@
+package ai.lum.odinson.utils
+
+import java.io.{ByteArrayInputStream, File, InputStream}
+import java.nio.charset.StandardCharsets
+
+import ai.lum.common.FileUtils._
+import ai.lum.odinson.utils.RuleSources.RuleSources
+
+case class SituatedStream(stream: InputStream, canonicalPath: String, from: RuleSources) {
+  def relativePathStream(path: String): SituatedStream = {
+    val newPath = resolveRelativePath(path)
+    from match {
+      case RuleSources.resource => SituatedStream.fromResource(newPath)
+      case RuleSources.file => SituatedStream.fromFile(newPath)
+      case _ => ???
+    }
+  }
+
+  def resolveRelativePath(path: String): String = {
+    if (isAbsolute(path)) {
+      return path
+    }
+    // handle relative
+    from match {
+      case RuleSources.resource =>
+        var prevPath = canonicalPath
+        if (!prevPath.endsWith("/")) prevPath += "/"
+        prevPath + path
+      case RuleSources.file => new File(canonicalPath, path).getCanonicalPath
+      case RuleSources.string => throw new RuntimeException("Strings don't support imports and relative paths")
+    }
+  }
+
+  def isAbsolute(path: String): Boolean = from match {
+    case RuleSources.file => new File(path).isAbsolute
+    case RuleSources.resource => path.startsWith("/")
+    case _ => ???
+  }
+}
+
+object SituatedStream {
+  val NO_PATH = "NO_PATH"
+
+  def fromFile(canonicalPath: String): SituatedStream = {
+    new SituatedStream(new File(canonicalPath).toInputStream, canonicalPath, RuleSources.file)
+  }
+
+  def fromResource(resourcePath: String): SituatedStream = {
+    val stream = getClass.getResourceAsStream(resourcePath)
+    new SituatedStream(stream, resourcePath, RuleSources.resource)
+  }
+
+  def fromString(s: String): SituatedStream = {
+    val stream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8))
+    new SituatedStream(stream, SituatedStream.NO_PATH, RuleSources.string)
+  }
+}
+
+object RuleSources extends Enumeration {
+  type RuleSources = Value
+  val resource = Value("resource")
+  val file = Value("file")
+  val string = Value("string")
+}

--- a/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
@@ -30,7 +30,9 @@ case class SituatedStream(stream: InputStream, canonicalPath: String, from: Rule
           prevPath += "/"
         }
         prevPath + path
-      case RuleSources.file => new File(canonicalPath, path).getCanonicalPath
+      case RuleSources.file =>
+        val parent = new File(canonicalPath).getParentFile.getCanonicalPath
+        new File(parent, path).getCanonicalPath
       case RuleSources.string => throw new RuntimeException("Strings don't support imports and relative paths")
     }
   }

--- a/core/src/test/resources/testGrammar/imported/a.yml
+++ b/core/src/test/resources/testGrammar/imported/a.yml
@@ -1,0 +1,7 @@
+rules:
+  - name: testRuleImported-${label}
+    type: event
+    pattern: |
+      trigger = [lemma=eat]
+      subject: ^NP = >nsubj ${chunk}
+      object: ^NP = >dobj ${chunk}

--- a/core/src/test/resources/testGrammar/imported/a.yml
+++ b/core/src/test/resources/testGrammar/imported/a.yml
@@ -1,7 +1,12 @@
+vars:
+  name: "A"
+
 rules:
-  - name: testRuleImported-${label}
-    type: event
+  - name: A-${name}
+    type: basic
     pattern: |
-      trigger = [lemma=eat]
-      subject: ^NP = >nsubj ${chunk}
-      object: ^NP = >dobj ${chunk}
+      machines
+
+  - import: ../imported/b.yml
+    vars:
+      name: "IMPORT_FROM_A"

--- a/core/src/test/resources/testGrammar/imported/b.yml
+++ b/core/src/test/resources/testGrammar/imported/b.yml
@@ -1,8 +1,8 @@
 vars:
-  name: "A"
+  name: "B"
 
 rules:
-  - name: A-${name}
+  - name: B-${name}
     type: basic
     pattern: |
-      ramen
+      leads

--- a/core/src/test/resources/testGrammar/imported/b.yml
+++ b/core/src/test/resources/testGrammar/imported/b.yml
@@ -1,0 +1,8 @@
+vars:
+  name: "A"
+
+rules:
+  - name: A-${name}
+    type: basic
+    pattern: |
+      ramen

--- a/core/src/test/resources/testGrammar/imported/c.yml
+++ b/core/src/test/resources/testGrammar/imported/c.yml
@@ -1,0 +1,10 @@
+vars:
+  name: "C"
+  local: "LOCAL"
+  otherName: "OTHER_LOCAL"
+
+rules:
+  - name: C-${name}-${local}-${otherName}
+    type: basic
+    pattern: |
+      fact

--- a/core/src/test/resources/testGrammar/testMaster.yml
+++ b/core/src/test/resources/testGrammar/testMaster.yml
@@ -1,9 +1,13 @@
 vars:
   chunk: "[chunk=B-NP][chunk=I-NP]*"
   label: "PARENT_LABEL"
+  name: "MASTER_TOP"
 
 rules:
   - import: testRules.yml
     vars:
       label: "IMPORT_LABEL"
 
+  - import: imported/a.yml
+    vars:
+      name: "IMPORT_FROM_MASTER"

--- a/core/src/test/resources/testGrammar/testMaster.yml
+++ b/core/src/test/resources/testGrammar/testMaster.yml
@@ -1,0 +1,7 @@
+vars:
+  chunk: "[chunk=B-NP][chunk=I-NP]*"
+  label: "TEST_LABEL"
+
+rules:
+  - import: testRules.yml
+

--- a/core/src/test/resources/testGrammar/testMaster.yml
+++ b/core/src/test/resources/testGrammar/testMaster.yml
@@ -1,7 +1,9 @@
 vars:
   chunk: "[chunk=B-NP][chunk=I-NP]*"
-  label: "TEST_LABEL"
+  label: "PARENT_LABEL"
 
 rules:
   - import: testRules.yml
+    vars:
+      label: "IMPORT_LABEL"
 

--- a/core/src/test/resources/testGrammar/testPaths.yml
+++ b/core/src/test/resources/testGrammar/testPaths.yml
@@ -1,7 +1,10 @@
 vars:
   chunk: "[chunk=B-NP][chunk=I-NP]*"
+  local: "PARENT"
 
 rules:
-  - import: /testGrammar/imported/b.yml
+  - import: /testGrammar/imported/a.yml
     vars:
       name: "IMPORT_NAME"
+
+  - import: imported/c.yml

--- a/core/src/test/resources/testGrammar/testPaths.yml
+++ b/core/src/test/resources/testGrammar/testPaths.yml
@@ -1,0 +1,7 @@
+vars:
+  chunk: "[chunk=B-NP][chunk=I-NP]*"
+
+rules:
+  - import: /testGrammar/imported/b.yml
+    vars:
+      name: "IMPORT_NAME"

--- a/core/src/test/resources/testGrammar/testRules.yml
+++ b/core/src/test/resources/testGrammar/testRules.yml
@@ -1,0 +1,7 @@
+rules:
+  - name: testRuleImported-${label}
+    type: event
+    pattern: |
+      trigger = [lemma=eat]
+      subject: ^NP = >nsubj ${chunk}
+      object: ^NP = >dobj ${chunk}

--- a/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
@@ -51,7 +51,7 @@ class TestEventTriggers extends EventSpec {
       varsResult = "([tag=/J.*/]{,3} [tag=/N.*/]+ (of [tag=DT]? [tag=/J.*/]{,3} [tag=/N.*/]+)?)"
     )
     
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
@@ -67,7 +67,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
     
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
@@ -83,7 +83,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
     
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
@@ -99,7 +99,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
 
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
@@ -118,7 +118,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = "<amod [lemma=animal]",
     )
     
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
@@ -136,7 +136,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternTrigger = "some []* animals",
       rulesPatternResult = "(<nmod_such_as | >nmod_including) >/conj.*/? ${result}",
     )
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
@@ -154,7 +154,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternTrigger = "some []* animals",
       rulesPatternResult = "(>nmod_such_as | >nmod_including) >/conj.*/? ${result}",
     )
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors, allowTriggerOverlaps = true)
     val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
@@ -175,7 +175,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternTrigger = "some []*? animals",
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val triggers = mentions.map(m => ee.getString(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
@@ -192,7 +192,7 @@ class TestEventTriggers extends EventSpec {
       varsResult = "([tag=/J.*/]{,3} [tag=/N.*/]+ (of [tag=DT]? [tag=/J.*/]{,3} [tag=/N.*/]+)?)",
       rulesPattern = "animals >nmod_such_as >/conj.*/? (?<result>${result})",
     )
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")
@@ -208,7 +208,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
     
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     val animals = mentions.map(m => ee.getString(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")

--- a/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
@@ -190,7 +190,7 @@ class TestEvents extends EventSpec {
       |      object: Bear = >dobj
        """.stripMargin
 
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
 
     mentions should have size 2

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -18,7 +18,7 @@ class TestRuleFile extends EventSpec {
       |      subject: ^NP = >nsubj ${chunk}
       |      object: ^NP = >dobj ${chunk}
     """.stripMargin
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.ruleReader.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     mentions should have size 1
     val m = mentions.head.odinsonMatch
@@ -52,9 +52,25 @@ class TestRuleFile extends EventSpec {
         |    pattern: |
         |      [norm=/${turtle}/]
        """.stripMargin
-    val extractors = ee.ruleReader.compileRuleFile(rules)
+    val extractors = ee.compileRuleString(rules)
     val mentions = ee.extractMentions(extractors)
     mentions should have size 2
   }
+
+  it should "allow rules to be imported in a master rule file" in {
+    val masterPath = "/testGrammar/testMaster.yml"
+    val extractors = ee.compileRuleResource(masterPath)
+    val mentions = ee.extractMentions(extractors)
+    mentions should have size 1
+    // Tests that the variables from the master file propagate
+    mentions.head.foundBy should be("testRuleImported-TEST_LABEL")
+  }
+
+  // todo:
+  //  1: import in a string should throw an exception
+  //  2: a string w/o import should not throw an exception
+  //  3: test resources with absolute and relative paths (with .. notation)
+  //  4: test filesystem resources -- write temp directory with files, put a grammar there, delete when done (if possible)
+  //  5: test that the hard-coded > import > parent > local
 
 }

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -1,9 +1,17 @@
 package ai.lum.odinson.events
 
+import ai.lum.common.FileUtils._
+import java.io.File
+import java.nio.file.{Files, Path}
+
 class TestRuleFile extends EventSpec {
   // extractor engine persists across tests (hacky way)
-  def doc = getDocument("becky-gummy-bears-v2")
-  def ee = Utils.mkExtractorEngine(doc)
+  def docGummy = getDocument("becky-gummy-bears-v2")
+  def eeGummy = Utils.mkExtractorEngine(docGummy)
+
+  // Leonardo leads, Donatello does machines (That's a fact, jack!)
+  val docNinja = getDocument("ninja-turtles")
+  val eeNinja = Utils.mkExtractorEngine(docNinja)
 
   "Odinson" should "match event with rules defined in a rule file" in {
     val rules = """
@@ -18,8 +26,8 @@ class TestRuleFile extends EventSpec {
       |      subject: ^NP = >nsubj ${chunk}
       |      object: ^NP = >dobj ${chunk}
     """.stripMargin
-    val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val extractors = eeGummy.ruleReader.compileRuleString(rules)
+    val mentions = eeGummy.extractMentions(extractors)
     mentions should have size 1
     val m = mentions.head.odinsonMatch
     // test trigger
@@ -33,9 +41,6 @@ class TestRuleFile extends EventSpec {
   }
 
   it should "correctly handle list vars" in {
-    // Leonardo leads, Donatello does machines (That's a fact, jack!)
-    val doc = getDocument("ninja-turtles")
-    val ee = Utils.mkExtractorEngine(doc)
     val rules =
       """
         |vars:
@@ -52,15 +57,15 @@ class TestRuleFile extends EventSpec {
         |    pattern: |
         |      [norm=/${turtle}/]
        """.stripMargin
-    val extractors = ee.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val extractors = eeNinja.compileRuleString(rules)
+    val mentions = eeNinja.extractMentions(extractors)
     mentions should have size 2
   }
 
   it should "allow rules to be imported in a master rule file" in {
     val masterPath = "/testGrammar/testMaster.yml"
-    val extractors = ee.compileRuleResource(masterPath)
-    val mentions = ee.extractMentions(extractors)
+    val extractors = eeGummy.compileRuleResource(masterPath)
+    val mentions = eeGummy.extractMentions(extractors)
     mentions should have size 1
     // Tests that the variables from the master file propagate
     mentions.head.foundBy should be("testRuleImported-IMPORT_LABEL")
@@ -68,9 +73,112 @@ class TestRuleFile extends EventSpec {
 
   // todo:
   //  1: import in a string should throw an exception
-  //  2: a string w/o import should not throw an exception
+  it should "throw an exception with imports in string" in {
+    // Leonardo leads, Donatello does machines (That's a fact, jack!)
+    val doc = getDocument("ninja-turtles")
+    val ee = Utils.mkExtractorEngine(doc)
+    val rules =
+      """
+        |vars:
+        |  turtle:
+        |     - leonardo
+        |     - donatello
+        |     - raphael
+        |     - michelangelo
+        |
+        |rules:
+        |  - import: /testGrammar/testRules.yml
+        |
+       """.stripMargin
+    assertThrows[AssertionError]{
+      ee.compileRuleString(rules)
+    }
+  }
+  //  2: a string w/o import should not throw an exception -- see above
+
   //  3: test resources with absolute and relative paths (with .. notation)
-  //  4: test filesystem resources -- write temp directory with files, put a grammar there, delete when done (if possible)
   //  5: test that the hard-coded > import > parent > local
+  it should "allow resource file imports with absolute and relative paths and handle variables" in {
+    val masterPath = "/testGrammar/testPaths.yml"
+    val extractors = eeNinja.compileRuleResource(masterPath, Map("otherName" -> "HARD_CODED"))
+    val mentions = eeNinja.extractMentions(extractors)
+    mentions should have size 3
+    val leadsMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "leads")
+    assert(leadsMentions.length == 1)
+    // because import beats both parent (in a.yml) and local (in b.yml)
+    leadsMentions.head.foundBy should be("B-IMPORT_FROM_A")
+
+    val machinesMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "machines")
+    assert(machinesMentions.length == 1)
+    // because import beats both parent and local
+    machinesMentions.head.foundBy should be("A-IMPORT_NAME")
+
+    val factMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "fact")
+    assert(factMentions.length == 1)
+    // no import, but parent beats local, and hard-coded trumps all
+    factMentions.head.foundBy should be("C-C-PARENT-HARD_CODED")
+  }
+
+  //  4: test filesystem resources -- write temp directory with files, put a grammar there, delete when done (if possible)
+  it should "allow for absolute and relative paths in filesystem" in {
+    val tempDir = Files.createDirectory(new File("tmp-grammar").toPath).toFile
+    tempDir.deleteOnExit()
+
+    val masterFile = new File(tempDir, "tmpMaster.yml")
+    masterFile.deleteOnExit()
+
+    val importDir = Files.createDirectory(new File("tmp-grammar", "imported").toPath).toFile
+    importDir.deleteOnExit()
+
+    val aFile = new File(importDir, "a.yml")
+    aFile.deleteOnExit()
+
+    val bFile = new File(importDir, "b.yml")
+    bFile.deleteOnExit()
+
+    val bRelative = new File("imported", "b.yml")
+
+    val masterContents =
+      s"""
+        |vars:
+        |  chunk: "[chunk=B-NP][chunk=I-NP]*"
+        |
+        |rules:
+        |  - import: ${aFile.getAbsolutePath}
+        |
+        |  - import: ${bRelative}
+        """.stripMargin
+
+    val aContents =
+      """
+        |rules:
+        |  - name: A
+        |    type: basic
+        |    pattern: |
+        |      machines
+        """.stripMargin
+
+    val bContents =
+      """
+        |rules:
+        |  - name: B
+        |    type: basic
+        |    pattern: |
+        |      leads
+        """.stripMargin
+
+    masterFile.writeString(masterContents)
+    aFile.writeString(aContents)
+    bFile.writeString(bContents)
+
+    val extractors = eeNinja.compileRuleFile(masterFile)
+    val mentions = eeNinja.extractMentions(extractors)
+    mentions should have size 2
+    val leadsMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "leads")
+    assert(leadsMentions.length == 1)
+
+    val machinesMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "machines")
+    assert(machinesMentions.length == 1)
+  }
 
 }

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -63,7 +63,7 @@ class TestRuleFile extends EventSpec {
     val mentions = ee.extractMentions(extractors)
     mentions should have size 1
     // Tests that the variables from the master file propagate
-    mentions.head.foundBy should be("testRuleImported-TEST_LABEL")
+    mentions.head.foundBy should be("testRuleImported-IMPORT_LABEL")
   }
 
   // todo:

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -90,7 +90,7 @@ class TestRuleFile extends EventSpec {
         |  - import: /testGrammar/testRules.yml
         |
        """.stripMargin
-    assertThrows[AssertionError]{
+    assertThrows[RuntimeException]{
       ee.compileRuleString(rules)
     }
   }
@@ -121,13 +121,13 @@ class TestRuleFile extends EventSpec {
 
   //  4: test filesystem resources -- write temp directory with files, put a grammar there, delete when done (if possible)
   it should "allow for absolute and relative paths in filesystem" in {
-    val tempDir = Files.createDirectory(new File("tmp-grammar").toPath).toFile
+    val tempDir = Files.createTempDirectory("tmp-grammar").toFile
     tempDir.deleteOnExit()
 
     val masterFile = new File(tempDir, "tmpMaster.yml")
     masterFile.deleteOnExit()
 
-    val importDir = Files.createDirectory(new File("tmp-grammar", "imported").toPath).toFile
+    val importDir = Files.createDirectory(new File(tempDir, "imported").toPath).toFile
     importDir.deleteOnExit()
 
     val aFile = new File(importDir, "a.yml")

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -103,17 +103,17 @@ class TestRuleFile extends EventSpec {
     val extractors = eeNinja.compileRuleResource(masterPath, Map("otherName" -> "HARD_CODED"))
     val mentions = eeNinja.extractMentions(extractors)
     mentions should have size 3
-    val leadsMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "leads")
+    val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
     // because import beats both parent (in a.yml) and local (in b.yml)
     leadsMentions.head.foundBy should be("B-IMPORT_FROM_A")
 
-    val machinesMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "machines")
+    val machinesMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "machines")
     assert(machinesMentions.length == 1)
     // because import beats both parent and local
     machinesMentions.head.foundBy should be("A-IMPORT_NAME")
 
-    val factMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "fact")
+    val factMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "fact")
     assert(factMentions.length == 1)
     // no import, but parent beats local, and hard-coded trumps all
     factMentions.head.foundBy should be("C-C-PARENT-HARD_CODED")
@@ -174,10 +174,10 @@ class TestRuleFile extends EventSpec {
     val extractors = eeNinja.compileRuleFile(masterFile)
     val mentions = eeNinja.extractMentions(extractors)
     mentions should have size 2
-    val leadsMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "leads")
+    val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
 
-    val machinesMentions = mentions.filter(m => eeNinja.getString(m.luceneDocId, m.odinsonMatch) == "machines")
+    val machinesMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "machines")
     assert(machinesMentions.length == 1)
   }
 

--- a/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
@@ -38,12 +38,10 @@ object Example extends App with LazyLogging{
   val config = ConfigFactory.load()
   val outputFile: File = config[File]("odinson.extra.outputFile")
   val rulesFile: File = config[File]("odinson.extra.rulesFile")
-  // Read the contents
-  val rules = rulesFile.readString()
 
   // Initialize the extractor engine, using the index specified in the config
   val extractorEngine = ExtractorEngine.fromConfig()
-  val extractors = extractorEngine.ruleReader.compileRuleFile(rules)
+  val extractors = extractorEngine.ruleReader.compileRuleFile(rulesFile)
 
   // Extract Mentions
   val mentions = extractorEngine.extractMentions(extractors)


### PR DESCRIPTION
allowing for imports in the odinson grammars, both from resources and file system, with absolute and relative paths.
Variable scoping is supported, such that: 
    
```
hard-coded (e.g., passed in from outside grammar) > 
imported (i.e., during import) > 
parent (e.g., master) > 
local
```

@marcovzla  and @kwalcock , please let me know what changes you would like made, thanks!

closes #153 