### PR TITLE
clarify expectations of argmetadata

### DIFF
--- a/core/src/main/scala/ai/lum/odinson/OdinsonMatch.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonMatch.scala
@@ -78,7 +78,9 @@ class EventSketch(
   val start: Int = trigger.start
   val end: Int = trigger.end
   val namedCaptures: Array[NamedCapture] = OdinsonMatch.emptyNamedCaptures
-  val argumentMetadata: Array[ArgumentMetadata] = argSketches.map(a => ArgumentMetadata(a._1.name, a._1.min, a._1.max))
+  val argumentMetadata: Array[ArgumentMetadata] = argSketches
+    .map(a => ArgumentMetadata(a._1.name, a._1.min, a._1.max))
+    .distinct
 }
 
 class NGramMatch(

--- a/core/src/main/scala/ai/lum/odinson/compiler/Ast.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/Ast.scala
@@ -36,7 +36,18 @@ object Ast {
   case class ExpandPattern(pattern: Pattern) extends Pattern
 
   // FIXME should these be `Pattern` or something else?
-  case class EventPattern(trigger: Pattern, arguments: List[ArgumentPattern]) extends Pattern
+  case class EventPattern(trigger: Pattern, arguments: List[ArgumentPattern]) extends Pattern {
+    // We don't currently allow more than one argument with the same name
+    // Check to make sure this doesn't happen.
+    argCheck()
+
+    def argCheck(): Unit = {
+     val argNames = arguments.map(_.name)
+     if (argNames.toSet.size < argNames.length) {
+       throw new RuntimeException("There are multiple arguments with the same name in EventPattern.")
+     }
+    }
+  }
   case class ArgumentPattern(
     name: String,
     label: Option[String],

--- a/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
@@ -1,5 +1,7 @@
 package ai.lum.odinson.events
 
+import ai.lum.odinson.EventMatch
+
 
 class TestEvents extends EventSpec {
 
@@ -49,6 +51,30 @@ class TestEvents extends EventSpec {
       createArgument("object", 2, 4),
     )
     testEventArguments(m, desiredArgs)
+  }
+
+  it should "have only one argument metadata with any given name" in {
+    val rule = """
+      |rules:
+      |  - name: testrule
+      |    type: event
+      |    pattern: |
+      |      trigger = [lemma=eat]
+      |      subject: ^NP = >nsubj [chunk=B-NP][chunk=I-NP]*
+      |      object: ^NP = >dobj gummy? bears
+    """.stripMargin
+    // the above rule should match {bears} and {gummy bears}
+    // and then keep only {gummy bears} because the quantifier `?` is greedy
+    val extractors = ee.compileRuleString(rule)
+    val mentions = ee.extractMentions(extractors)
+    mentions.length should equal (1)
+    mentions.head.odinsonMatch shouldBe a [EventMatch]
+    val em = mentions.head.odinsonMatch.asInstanceOf[EventMatch]
+    val argMetadataNames = em.argumentMetadata.toSeq.map(_.name)
+    // the length of this list should not change if it goes to a set
+    argMetadataNames.length should be(argMetadataNames.toSet.size)
+
+
   }
 
   it should "promote a token when no surface pattern is provided" in {
@@ -219,5 +245,26 @@ class TestEvents extends EventSpec {
     objType should have size(1)
     testEventArguments(obj.odinsonMatch, desiredBearArg)
   }
+
+  // We can revisit the semantics here if desired
+  it should "not allow two arguments with the same name" in {
+
+    val rules =
+      """
+        |rules:
+        |  - name: bears-rule
+        |    label: Bear
+        |    type: event
+        |    priority: 1
+        |    pattern: |
+        |      trigger = bears
+        |      ARG = >amod []
+        |      ARG = <dobj []
+       """.stripMargin
+
+    a [RuntimeException] should be thrownBy ee.ruleReader.compileRuleString(rules)
+
+  }
+
 
 }


### PR DESCRIPTION
OK, so with these fixes, we shouldn't have the case that there are multiple argMetadatas with the same name because we're:
1. disallowing multiple arguments with the same name and
2. calling `distinct` on the metadatas when we make the EventSketch (previously, before the `MatchSelector` packages the args, when there are multiple ways an argument can be matched (as was the case with the optional `gummy?` in the TestEvents test), there were repeated argument metadatas).

I added two tests for these desired behaviors.  I think now @kwalcock may be able to simplify the promotion in #182 ...?

I think this closes #186 