### PR TITLE
odinsonexception and a test

### DIFF
--- a/core/src/main/scala/ai/lum/odinson/compiler/Ast.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/Ast.scala
@@ -1,5 +1,7 @@
 package ai.lum.odinson.compiler
 
+import ai.lum.odinson.utils.exceptions.OdinsonException
+
 object Ast {
 
   sealed trait Matcher
@@ -44,7 +46,7 @@ object Ast {
     def argCheck(): Unit = {
      val argNames = arguments.map(_.name)
      if (argNames.toSet.size < argNames.length) {
-       throw new RuntimeException("There are multiple arguments with the same name in EventPattern.")
+       throw new OdinsonException("There are multiple arguments with the same name in EventPattern.")
      }
     }
   }

--- a/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/SituatedStream.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 
 import ai.lum.common.FileUtils._
 import ai.lum.odinson.utils.RuleSources.RuleSources
+import ai.lum.odinson.utils.exceptions.OdinsonException
 
 case class SituatedStream(stream: InputStream, canonicalPath: String, from: RuleSources) {
   def relativePathStream(path: String): SituatedStream = {
@@ -33,7 +34,7 @@ case class SituatedStream(stream: InputStream, canonicalPath: String, from: Rule
       case RuleSources.file =>
         val parent = new File(canonicalPath).getParentFile.getCanonicalPath
         new File(parent, path).getCanonicalPath
-      case RuleSources.string => throw new RuntimeException("Strings don't support imports and relative paths")
+      case RuleSources.string => throw new OdinsonException("Strings don't support imports and relative paths")
     }
   }
 

--- a/core/src/main/scala/ai/lum/odinson/utils/exceptions/OdinsonException.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/exceptions/OdinsonException.scala
@@ -1,0 +1,3 @@
+package ai.lum.odinson.utils.exceptions
+
+class OdinsonException(message: String) extends Exception(message) {}

--- a/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
@@ -1,6 +1,7 @@
 package ai.lum.odinson.events
 
 import ai.lum.odinson.EventMatch
+import ai.lum.odinson.utils.exceptions.OdinsonException
 
 
 class TestEvents extends EventSpec {
@@ -262,7 +263,7 @@ class TestEvents extends EventSpec {
         |      ARG = <dobj []
        """.stripMargin
 
-    a [RuntimeException] should be thrownBy ee.ruleReader.compileRuleString(rules)
+    a [OdinsonException] should be thrownBy ee.ruleReader.compileRuleString(rules)
 
   }
 

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -4,6 +4,8 @@ import ai.lum.common.FileUtils._
 import java.io.File
 import java.nio.file.{Files, Path}
 
+import ai.lum.odinson.utils.exceptions.OdinsonException
+
 class TestRuleFile extends EventSpec {
   // extractor engine persists across tests (hacky way)
   def docGummy = getDocument("becky-gummy-bears-v2")
@@ -90,7 +92,7 @@ class TestRuleFile extends EventSpec {
         |  - import: /testGrammar/testRules.yml
         |
        """.stripMargin
-    assertThrows[RuntimeException]{
+    assertThrows[OdinsonException]{
       ee.compileRuleString(rules)
     }
   }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestExceptions.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestExceptions.scala
@@ -1,0 +1,22 @@
+package ai.lum.odinson.foundations
+
+import ai.lum.odinson.BaseSpec
+import ai.lum.odinson.utils.exceptions.OdinsonException
+
+class TestExceptions extends BaseSpec {
+
+  "OdinsonException" should "properly throw exceptions" in {
+
+    def exceptionThrower(bool: Boolean) = {
+      bool match {
+        case true => throw new OdinsonException("we threw an odinson exception!")
+        case false => ()
+      }
+    }
+
+    noException should be thrownBy exceptionThrower(false)
+    an [OdinsonException] should be thrownBy exceptionThrower(true)
+    an [Exception] should be thrownBy exceptionThrower(true)
+  }
+
+}


### PR DESCRIPTION
IDK if the test was necessary, if it's just cluttering, we can remove.

Also -- if people want this moved somewhere else, just let me know.  I can move it trivially.
Currently in `package ai.lum.odinson.utils.exceptions`

Replaced several RuntimeExceptions in the code and the tests.  There are some other more specialized exceptions which may or may not get replaced.

closes #195 