### PR TITLE
Rearrange the extractMentions for state/noState

### DIFF
--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -215,7 +215,11 @@ class OdinsonController @Inject() (system: ActorSystem, cc: ControllerComponents
         case None => extractorEngine.numDocs()
       }
 
-      val mentions: Seq[Mention] = extractorEngine.extractMentions(composedExtractors, numSentences = maxSentences, allowTriggerOverlaps = allowTriggerOverlaps, disableMatchSelector = false)
+      val mentions: Seq[Mention] = {
+        // FIXME: should deal in iterators to allow for, e.g., pagination...?
+        val iterator = extractorEngine.extractMentions(composedExtractors, numSentences = maxSentences, allowTriggerOverlaps = allowTriggerOverlaps, disableMatchSelector = false)
+        iterator.toVector
+      }
       
       val duration = (System.currentTimeMillis() - start) / 1000f // duration in seconds
 

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -142,7 +142,7 @@ class ExtractorEngine(
   }
 
   private def extract(i: Int, state: State, extractors: Seq[Extractor], numSentences: Int, disableMatchSelector: Boolean, mruIdGetter:MostRecentlyUsed[Int, LazyIdGetter]): Seq[Mention] = {
-    for {
+    val resultsIterators = for {
       extractor <- extractors
       if extractor.priority matches i
       odinResults = query(extractor.query, extractor.label, Some(extractor.name), numSentences, null, disableMatchSelector, state)

--- a/core/src/main/scala/ai/lum/odinson/MentionFactory.scala
+++ b/core/src/main/scala/ai/lum/odinson/MentionFactory.scala
@@ -1,5 +1,8 @@
 package ai.lum.odinson
 
+import ai.lum.odinson.state.ResultItem
+import ai.lum.odinson.utils.MostRecentlyUsed
+
 trait IdGetter {
   def getDocId: String
   def getSentId: String
@@ -31,6 +34,17 @@ trait MentionFactory {
   ): Mention = {
     val arguments = mkArguments(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, idGetter, foundBy)
     newMention(odinsonMatch, label, luceneDocId, luceneSegmentDocId, luceneSegmentDocBase, idGetter, foundBy, arguments)
+  }
+
+  def newMention(resultItem: ResultItem, mruIdGetter: MostRecentlyUsed[Int, LazyIdGetter]): Mention = {
+    newMention(
+      resultItem.odinsonMatch,
+      Some(resultItem.label),
+      resultItem.docIndex,
+      resultItem.segmentDocId,
+      resultItem.segmentDocBase,
+      mruIdGetter.getOrNew(resultItem.docIndex),
+      resultItem.name)
   }
 
   /** A map from argument name to a sequence of matches.

--- a/core/src/main/scala/ai/lum/odinson/state/FileState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/FileState.scala
@@ -9,6 +9,8 @@ class FileState extends State {
   override def getDocIds(docBase: Int, label: String): Array[Int] = ???
 
   override def getResultItems(docBase: Int, docId: Int, label: String): Array[ResultItem] = ???
+
+  override def getAllResultItems(): Iterator[ResultItem] = ???
 }
 
 class FileStateFactory extends StateFactory {

--- a/core/src/main/scala/ai/lum/odinson/state/MemoryState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/MemoryState.scala
@@ -45,6 +45,14 @@ class MemoryState extends State {
 
     resultItems
   }
+
+  override def getAllResultItems(): Iterator[ResultItem] = {
+    val resultItemsIterator = baseIdLabelToResultItems
+      .toIterator
+      .flatMap{ case (baseIdLabel, resultItemSet) => resultItemSet.toIterator }
+    // TODO: @Keith check please :)
+    resultItemsIterator
+  }
 }
 
 object MemoryState {

--- a/core/src/main/scala/ai/lum/odinson/state/MockState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/MockState.scala
@@ -1,5 +1,6 @@
 package ai.lum.odinson.state
 
+import ai.lum.odinson.state.OdinResultsIterator.emptyResultIterator
 import com.typesafe.config.Config
 
 
@@ -11,6 +12,8 @@ object MockState extends State {
   def getDocIds(docBase: Int, label: String): Array[Int] = Array.emptyIntArray
 
   def getResultItems(docBase: Int, docId: Int, label: String): Array[ResultItem] = emptyResultItemArray
+
+  override def getAllResultItems(): Iterator[ResultItem] = emptyResultIterator
 }
 
 

--- a/core/src/main/scala/ai/lum/odinson/state/OdinResultsIterator.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/OdinResultsIterator.scala
@@ -54,5 +54,10 @@ class OdinResultsIterator(labelOpt: Option[String], nameOpt: Option[String], odi
 }
 
 object OdinResultsIterator {
+  val emptyResultIterator = Iterator[ResultItem]()
   def apply(labelOpt: Option[String], nameOpt: Option[String], odinResults: OdinResults): OdinResultsIterator = new OdinResultsIterator(labelOpt, nameOpt, odinResults)
+
+  def concatenate(iterators: Seq[Iterator[ResultItem]]): Iterator[ResultItem] = {
+    iterators.foldLeft(emptyResultIterator)(_ ++ _)
+  }
 }

--- a/core/src/main/scala/ai/lum/odinson/state/SqlState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/SqlState.scala
@@ -263,6 +263,11 @@ class SqlState(val connection: Connection, protected val factoryIndex: Long, pro
     }
   }
 
+  override def getAllResultItems(): Iterator[ResultItem] = {
+    // TODO: Keith
+    ???
+  }
+
   override def close(): Unit = {
     if (!closed) {
       // Set this first so that failed drops are not attempted multiple times.

--- a/core/src/main/scala/ai/lum/odinson/state/State.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/State.scala
@@ -8,5 +8,7 @@ trait State {
 
   def getResultItems(docBase: Int, docId: Int, label: String): Array[ResultItem] // TODO: Return iterator
 
+  def getAllResultItems(): Iterator[ResultItem]
+
   def close(): Unit = ()
 }

--- a/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEventTriggers.scala
@@ -52,7 +52,7 @@ class TestEventTriggers extends EventSpec {
     )
     
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
@@ -68,7 +68,7 @@ class TestEventTriggers extends EventSpec {
     )
     
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
@@ -84,7 +84,7 @@ class TestEventTriggers extends EventSpec {
     )
     
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("hedgehogs", "coypu", "wild cloven-footed animals", "deer", "zoo animals")
     animals should contain theSameElementsInOrderAs expectedResults
@@ -100,7 +100,7 @@ class TestEventTriggers extends EventSpec {
     )
 
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("wild animals such", "wild animals such", "wild animals such", "wild cloven-footed animals such", "wild cloven-footed animals such")
@@ -119,7 +119,7 @@ class TestEventTriggers extends EventSpec {
     )
     
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild", "any wild")
@@ -137,7 +137,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = "(<nmod_such_as | >nmod_including) >/conj.*/? ${result}",
     )
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild animals such as hedgehogs , coypu , and any wild cloven-footed animals such as deer and zoo animals")
@@ -155,7 +155,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = "(>nmod_such_as | >nmod_including) >/conj.*/? ${result}",
     )
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors, allowTriggerOverlaps = true)
+    val mentions = ee.extractMentions(extractors, allowTriggerOverlaps = true).toArray
     val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers: List[String] = (1 to 6).map(
@@ -176,7 +176,7 @@ class TestEventTriggers extends EventSpec {
       rulesPatternResult = ">nmod_such_as >/conj.*/? ${result}",
     )
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val triggers = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.odinsonMatch.asInstanceOf[EventMatch].trigger))
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedTriggers = List("Some wild animals", "Some wild animals", "Some wild animals")
@@ -193,7 +193,7 @@ class TestEventTriggers extends EventSpec {
       rulesPattern = "animals >nmod_such_as >/conj.*/? (?<result>${result})",
     )
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")
     animals should contain theSameElementsInOrderAs expectedResults
@@ -209,7 +209,7 @@ class TestEventTriggers extends EventSpec {
     )
     
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     val animals = mentions.map(m => ee.getStringForSpan(m.luceneDocId, m.arguments("result").head.odinsonMatch))
     val expectedResults = List("rabbit", "possum", "quail", "badger", "iguana", "armadillo", "variety of river fish")
     animals should contain theSameElementsInOrderAs expectedResults

--- a/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
@@ -72,7 +72,7 @@ class TestEvents extends EventSpec {
     // the above rule should match {bears} and {gummy bears}
     // and then keep only {gummy bears} because the quantifier `?` is greedy
     val extractors = ee.compileRuleString(rule)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
     mentions.length should equal (1)
     mentions.head.odinsonMatch shouldBe a [EventMatch]
     val em = mentions.head.odinsonMatch.asInstanceOf[EventMatch]
@@ -234,7 +234,7 @@ class TestEvents extends EventSpec {
        """.stripMargin
 
     val extractors = ee.ruleReader.compileRuleString(rules)
-    val mentions = ee.extractMentions(extractors)
+    val mentions = ee.extractMentions(extractors).toArray
 
     mentions should have size(2)
 

--- a/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestRuleFile.scala
@@ -29,8 +29,8 @@ class TestRuleFile extends EventSpec {
       |      object: ^NP = >dobj ${chunk}
     """.stripMargin
     val extractors = eeGummy.ruleReader.compileRuleString(rules)
-    val mentions = eeGummy.extractMentions(extractors)
-    mentions should have size 1
+    val mentions = eeGummy.extractMentions(extractors).toArray
+    mentions should have size (1)
     val m = mentions.head.odinsonMatch
     // test trigger
     testEventTrigger(m, start = 1, end = 2)
@@ -60,15 +60,15 @@ class TestRuleFile extends EventSpec {
         |      [norm=/${turtle}/]
        """.stripMargin
     val extractors = eeNinja.compileRuleString(rules)
-    val mentions = eeNinja.extractMentions(extractors)
-    mentions should have size 2
+    val mentions = eeNinja.extractMentions(extractors).toArray
+    mentions should have size (2)
   }
 
   it should "allow rules to be imported in a master rule file" in {
     val masterPath = "/testGrammar/testMaster.yml"
     val extractors = eeGummy.compileRuleResource(masterPath)
-    val mentions = eeGummy.extractMentions(extractors)
-    mentions should have size 1
+    val mentions = eeGummy.extractMentions(extractors).toArray
+    mentions should have size (1)
     // Tests that the variables from the master file propagate
     mentions.head.foundBy should be("testRuleImported-IMPORT_LABEL")
   }
@@ -103,8 +103,8 @@ class TestRuleFile extends EventSpec {
   it should "allow resource file imports with absolute and relative paths and handle variables" in {
     val masterPath = "/testGrammar/testPaths.yml"
     val extractors = eeNinja.compileRuleResource(masterPath, Map("otherName" -> "HARD_CODED"))
-    val mentions = eeNinja.extractMentions(extractors)
-    mentions should have size 3
+    val mentions = eeNinja.extractMentions(extractors).toArray
+    mentions should have size (3)
     val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
     // because import beats both parent (in a.yml) and local (in b.yml)
@@ -174,7 +174,7 @@ class TestRuleFile extends EventSpec {
     bFile.writeString(bContents)
 
     val extractors = eeNinja.compileRuleFile(masterFile)
-    val mentions = eeNinja.extractMentions(extractors)
+    val mentions = eeNinja.extractMentions(extractors).toArray
     mentions should have size 2
     val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
@@ -186,8 +186,8 @@ class TestRuleFile extends EventSpec {
   it should "allow for importing vars from a resource" in {
     val masterPath = "/testGrammar/varImports/rules.yml"
     val extractors = eeNinja.compileRuleResource(masterPath)
-    val mentions = eeNinja.extractMentions(extractors)
-    mentions should have size 1
+    val mentions = eeNinja.extractMentions(extractors).toArray
+    mentions should have size (1)
     val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
     leadsMentions.head.foundBy should be("leads-IMPORTED_FROM_VARS")
@@ -223,8 +223,8 @@ class TestRuleFile extends EventSpec {
     varsFile.writeString(varsContents)
 
     val extractors = eeNinja.compileRuleFile(rulesFile)
-    val mentions = eeNinja.extractMentions(extractors)
-    mentions should have size 1
+    val mentions = eeNinja.extractMentions(extractors).toArray
+    mentions should have size (1)
     val leadsMentions = mentions.filter(m => eeNinja.getStringForSpan(m.luceneDocId, m.odinsonMatch) == "leads")
     assert(leadsMentions.length == 1)
     leadsMentions.head.foundBy should be("B-IMPORTED_NAME")

--- a/core/src/test/scala/ai/lum/odinson/state/TestMockState.scala
+++ b/core/src/test/scala/ai/lum/odinson/state/TestMockState.scala
@@ -38,7 +38,7 @@ class TestMockState extends BaseSpec {
        """.stripMargin
 
     val extractors = eeGummy.ruleReader.compileRuleString(rules)
-    val mentions = eeGummy.extractMentions(extractors)
+    val mentions = eeGummy.extractMentions(extractors).toArray
 
     mentions should have size (2)
 
@@ -76,7 +76,7 @@ class TestMockState extends BaseSpec {
        """.stripMargin
 
     val extractors = eeGummyMemory.ruleReader.compileRuleString(rules)
-    val mentions = eeGummyMemory.extractMentions(extractors)
+    val mentions = eeGummyMemory.extractMentions(extractors).toArray
 
     mentions should have size (3)
 

--- a/core/src/test/scala/ai/lum/odinson/state/TestState.scala
+++ b/core/src/test/scala/ai/lum/odinson/state/TestState.scala
@@ -43,7 +43,7 @@ class TestState extends BaseSpec{
        """.stripMargin
 
     val extractors = eeGummy.ruleReader.compileRuleString(rules)
-    val mentions = eeGummy.extractMentions(extractors)
+    val mentions = eeGummy.extractMentions(extractors).toArray
 
     val first = mentions.filter(_.label.get == "First")
     first should have size(1)


### PR DESCRIPTION
@kwalcock As promised, sir, here is something that I think does two things desired:
- uses iterators instead of Seq so we don't run out of memory
- IMPORTANT, doesn't add the results to the state until _after_ the entire epoch/priority is over, so that extractors from the same priority don't have (inappropriate) access to things found contemporaneously (what a big word, did I use it right?) :) 


1. Please look it over, scrutinize details and all...
2. I added a method to the State trait (`def getAllResultItems(): Iterator[ResultItem]`), I have an implementation in MockState (I'm just that awesome!), and one in MemoryState (that you should check), BUT I left the SQL one for you so you could have fun too.  You're welcome! :)

Thanks, and let's keep in touch!
