### PR TITLE
json strings and lines

### DIFF
--- a/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
+++ b/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
@@ -20,15 +20,15 @@ object JsonSerializer {
   }
 
   def asJsonPretty(ms: Seq[Mention], indent: Int): String = {
-    ujson.write(asJson(ms), indent)
+    ujson.write(asJsonValue(ms), indent)
   }
 
   def asJsonPretty(m: Mention): String = {
-    ujson.write(asJson(m), indent = 4)
+    ujson.write(asJsonValue(m), indent = 4)
   }
 
   def asJsonPretty(m: Mention, indent: Int): String = {
-    ujson.write(asJson(m), indent)
+    ujson.write(asJsonValue(m), indent)
   }
 
   def asJsonString(ms: Iterator[Mention]): String = {
@@ -36,15 +36,15 @@ object JsonSerializer {
   }
 
   def asJsonString(ms: Seq[Mention]): String = {
-    ujson.write(asJson(ms))
+    ujson.write(asJsonValue(ms))
   }
 
   def asJsonString(m: Mention): String = {
-    ujson.write(asJson(m))
+    ujson.write(asJsonValue(m))
   }
 
 
-  // Json Lines
+  // Json Lines (one mention json per line)
 
   def asJsonLines(ms: Iterator[Mention]): Seq[String] = {
     asJsonLines(ms.toSeq)
@@ -56,21 +56,21 @@ object JsonSerializer {
 
   // Json Value
 
-  def asJson(ms: Iterator[Mention]): Value = {
-    asJson(ms.toSeq)
+  def asJsonValue(ms: Iterator[Mention]): Value = {
+    asJsonValue(ms.toSeq)
   }
 
-  def asJson(ms: Seq[Mention]): Value = {
-    ms.map(asJson)
+  def asJsonValue(ms: Seq[Mention]): Value = {
+    ms.map(asJsonValue)
   }
 
-  def asJson(m: Mention): Value = {
+  def asJsonValue(m: Mention): Value = {
     val corpusDocId = m.idGetter.getDocId
     val corpusSentId = m.idGetter.getSentId
 
     ujson.Obj (
       "scalaType" -> m.getClass.getCanonicalName,
-      "odinsonMatch" -> asJson(m.odinsonMatch),
+      "odinsonMatch" -> asJsonValue(m.odinsonMatch),
       "label" -> stringOrNull(m.label),
       "luceneDocId" -> m.luceneDocId,
       "luceneSegmentDocId" -> m.luceneSegmentDocId,
@@ -78,11 +78,11 @@ object JsonSerializer {
       "docId" -> corpusDocId,
       "sentId" -> corpusSentId,
       "foundBy" -> m.foundBy,
-      "arguments" -> asJson(m.arguments)
+      "arguments" -> asJsonValue(m.arguments)
     )
   }
 
-  def asJson(om: OdinsonMatch): Value = {
+  def asJsonValue(om: OdinsonMatch): Value = {
     val scalaType = om.getClass.getCanonicalName
      om match {
       case sm: StateMatch =>
@@ -90,7 +90,7 @@ object JsonSerializer {
           "scalaType" -> scalaType,
           "start" -> sm.start,
           "end" -> sm.end,
-          "namedCaptures" -> sm.namedCaptures.map(asJson).toSeq
+          "namedCaptures" -> sm.namedCaptures.map(asJsonValue).toSeq
         )
       case ng: NGramMatch =>
         ujson.Obj(
@@ -101,49 +101,49 @@ object JsonSerializer {
       case em: EventMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "trigger" -> asJson(em.trigger),
-          "namedCaptures" -> em.namedCaptures.map(asJson).toSeq,
-          "argMetadata" -> asJson(em.argumentMetadata)
+          "trigger" -> asJsonValue(em.trigger),
+          "namedCaptures" -> em.namedCaptures.map(asJsonValue).toSeq,
+          "argMetadata" -> asJsonValue(em.argumentMetadata)
         )
 
       case gt: GraphTraversalMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "srcMatch" -> asJson(gt.srcMatch),
-          "dstMatch" -> asJson(gt.dstMatch),
+          "srcMatch" -> asJsonValue(gt.srcMatch),
+          "dstMatch" -> asJsonValue(gt.dstMatch),
         )
 
       case concat: ConcatMatch =>
       ujson.Obj(
         "scalaType" -> scalaType,
-        "subMatches" -> concat.subMatches.map(asJson).toSeq,
+        "subMatches" -> concat.subMatches.map(asJsonValue).toSeq,
       )
 
       case rep: RepetitionMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "subMatches" -> rep.subMatches.map(asJson).toSeq,
+          "subMatches" -> rep.subMatches.map(asJsonValue).toSeq,
           "isGreedy" -> rep.isGreedy,
         )
 
       case opt: OptionalMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "subMatch" -> asJson(opt.subMatch),
+          "subMatch" -> asJsonValue(opt.subMatch),
           "isGreedy" -> opt.isGreedy,
         )
 
       case or: OrMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "subMatch" -> asJson(or.subMatch),
+          "subMatch" -> asJsonValue(or.subMatch),
           "clauseID" -> or.clauseID
         )
 
       case named: NamedMatch =>
         ujson.Obj(
           "scalaType" -> scalaType,
-          "subMatch" -> asJson(named.subMatch),
+          "subMatch" -> asJsonValue(named.subMatch),
           "name" -> named.name,
           "label" -> stringOrNull(named.label),
         )
@@ -152,30 +152,30 @@ object JsonSerializer {
     }
   }
 
-  def asJson(n: NamedCapture): Value = {
+  def asJsonValue(n: NamedCapture): Value = {
     ujson.Obj(
       "scalaType" -> n.getClass.getCanonicalName,
       "name" -> n.name,
       "label" -> stringOrNull(n.label),
-      "capturedMatch" -> asJson(n.capturedMatch)
+      "capturedMatch" -> asJsonValue(n.capturedMatch)
     )
   }
 
-  def asJson(arguments: Map[String, Array[Mention]]): Value = {
+  def asJsonValue(arguments: Map[String, Array[Mention]]): Value = {
     val json = ujson.Obj()
     arguments.toIterator.foreach { case (argName, mentions) =>
-      json(argName) = mentions.map(asJson).toSeq
+      json(argName) = mentions.map(asJsonValue).toSeq
     }
     json
   }
 
-  def asJson(metadatas: Array[ArgumentMetadata]): Value = {
+  def asJsonValue(metadatas: Array[ArgumentMetadata]): Value = {
     ujson.Arr{
-      metadatas.map(asJson).toSeq
+      metadatas.map(asJsonValue).toSeq
     }
   }
 
-  def asJson(metadata: ArgumentMetadata): Value = {
+  def asJsonValue(metadata: ArgumentMetadata): Value = {
     ujson.Obj(
       "name" -> metadata.name,
       "min" -> metadata.min,

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -130,8 +130,8 @@ class TestJsonSerialization extends BaseSpec {
 
   "JsonSerializer" should "handle NGramMentions" in {
     val m = getMentionFromRule(mentions, "NGram")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -139,8 +139,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle basic EventMatches" in {
     val m = getMentionFromRule(mentions, "Event")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -148,8 +148,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg quantifiers" in {
     val m = getMentionFromRule(mentions, "Event-plus")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -157,8 +157,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg ranges" in {
     val m = getMentionFromRule(mentions, "Event-3")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -166,8 +166,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle GraphTraversals" in {
     val m = getMentionFromRule(mentions, "GraphTraversal")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -175,8 +175,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition" in {
     val m = getMentionFromRule(mentions, "Repetition")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -184,8 +184,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition (lazy)" in {
     val m = getMentionFromRule(mentions, "Repetition-lazy")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -193,8 +193,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Optional" in {
     val m = getMentionFromRule(mentions, "Optional")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -202,8 +202,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Or" in {
     val m = getMentionFromRule(mentions, "Or")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -211,8 +211,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Named" in {
     val m = getMentionFromRule(mentions, "Named")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -223,8 +223,8 @@ class TestJsonSerialization extends BaseSpec {
 
   "JsonSerializer" should "handle NGramMentions with State" in {
     val m = getMentionFromRule(stateMentions, "NGram")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -232,8 +232,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle basic EventMatches with State" in {
     val m = getMentionFromRule(stateMentions, "Event")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -241,8 +241,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg quantifiers with State" in {
     val m = getMentionFromRule(stateMentions, "Event-plus")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -250,8 +250,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg ranges with State" in {
     val m = getMentionFromRule(stateMentions, "Event-3")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -259,8 +259,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle GraphTraversals with State" in {
     val m = getMentionFromRule(stateMentions, "GraphTraversal")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -268,8 +268,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition with State" in {
     val m = getMentionFromRule(stateMentions, "Repetition")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -277,8 +277,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition (lazy) with State" in {
     val m = getMentionFromRule(stateMentions, "Repetition-lazy")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -286,8 +286,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Optional with State" in {
     val m = getMentionFromRule(stateMentions, "Optional")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -295,8 +295,8 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Or with State" in {
     val m = getMentionFromRule(stateMentions, "Or")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
@@ -304,11 +304,32 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Named with State" in {
     val m = getMentionFromRule(stateMentions, "Named")
-    val json = JsonSerializer.jsonify(Array(m))
-    val reconstituted = JsonSerializer.deserialize(json)
+    val json = JsonSerializer.asJson(Array(m))
+    val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
     mentionsAreEqual(m, reconstituted.head) should be (true)
+  }
+
+  it should "properly serialize and deserialized using json strings" in {
+    val m = getMentionFromRule(stateMentions, "Or")
+    val jsonString = JsonSerializer.asJsonString(m)
+    val deserialized = JsonSerializer.deserializeMention(jsonString)
+    mentionsAreEqual(m, deserialized) should be (true)
+
+    val jsonPretty = JsonSerializer.asJsonPretty(m)
+    val deserializedPretty = JsonSerializer.deserializeMention(jsonPretty)
+    mentionsAreEqual(m, deserializedPretty) should be (true)
+  }
+
+  it should "properly serialize and deserialized using json lines" in {
+    val m1 = getMentionFromRule(mentions, "Or")
+    val m2 = getMentionFromRule(mentions, "Named")
+    val jsonLines = JsonSerializer.asJsonLines(Seq(m1, m2))
+    val deserialized = JsonSerializer.deserializeJsonLines(jsonLines)
+    deserialized should have length (2)
+    mentionsAreEqual(m1, deserialized(0)) should be (true)
+    mentionsAreEqual(m2, deserialized(1)) should be (true)
   }
 
 }

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -130,7 +130,7 @@ class TestJsonSerialization extends BaseSpec {
 
   "JsonSerializer" should "handle NGramMentions" in {
     val m = getMentionFromRule(mentions, "NGram")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -139,7 +139,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle basic EventMatches" in {
     val m = getMentionFromRule(mentions, "Event")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -148,7 +148,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg quantifiers" in {
     val m = getMentionFromRule(mentions, "Event-plus")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -157,7 +157,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg ranges" in {
     val m = getMentionFromRule(mentions, "Event-3")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -166,7 +166,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle GraphTraversals" in {
     val m = getMentionFromRule(mentions, "GraphTraversal")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -175,7 +175,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition" in {
     val m = getMentionFromRule(mentions, "Repetition")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -184,7 +184,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition (lazy)" in {
     val m = getMentionFromRule(mentions, "Repetition-lazy")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -193,7 +193,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Optional" in {
     val m = getMentionFromRule(mentions, "Optional")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -202,7 +202,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Or" in {
     val m = getMentionFromRule(mentions, "Or")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -211,7 +211,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Named" in {
     val m = getMentionFromRule(mentions, "Named")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -223,7 +223,7 @@ class TestJsonSerialization extends BaseSpec {
 
   "JsonSerializer" should "handle NGramMentions with State" in {
     val m = getMentionFromRule(stateMentions, "NGram")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -232,7 +232,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle basic EventMatches with State" in {
     val m = getMentionFromRule(stateMentions, "Event")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -241,7 +241,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg quantifiers with State" in {
     val m = getMentionFromRule(stateMentions, "Event-plus")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -250,7 +250,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle EventMatches with arg ranges with State" in {
     val m = getMentionFromRule(stateMentions, "Event-3")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -259,7 +259,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle GraphTraversals with State" in {
     val m = getMentionFromRule(stateMentions, "GraphTraversal")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -268,7 +268,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition with State" in {
     val m = getMentionFromRule(stateMentions, "Repetition")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -277,7 +277,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Repetition (lazy) with State" in {
     val m = getMentionFromRule(stateMentions, "Repetition-lazy")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -286,7 +286,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Optional with State" in {
     val m = getMentionFromRule(stateMentions, "Optional")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -295,7 +295,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Or with State" in {
     val m = getMentionFromRule(stateMentions, "Or")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 
@@ -304,7 +304,7 @@ class TestJsonSerialization extends BaseSpec {
 
   it should "handle Named with State" in {
     val m = getMentionFromRule(stateMentions, "Named")
-    val json = JsonSerializer.asJson(Array(m))
+    val json = JsonSerializer.asJsonValue(Array(m))
     val reconstituted = JsonSerializer.deserializeMentions(json)
     reconstituted should have length(1)
 


### PR DESCRIPTION
Added json string, pretty, and json lines to serialization and deserialization. 
Renamed `jsonify` to `asJson` for consistent naming convention.