### PR TITLE
Optionally store all fields, and change namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added some additional methods to ExtractorEngine to access tokens from diff fields of a Lucene Doc ([#231](https://github.com/lum-ai/odinson/pull/231))
 - Added json serialization and deserialization of Mentions and OdinsonMatches to core ([#226](https://github.com/lum-ai/odinson/pull/226))
 - Added argument promotion, i.e., arguments specified for promotion or underspecified will be added to the state ([#218](https://github.com/lum-ai/odinson/pull/218))
 - Add tests for REST API endpoints
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Put indexing docs in a method to be used by external projects. ([#90](https://github.com/lum-ai/odinson/pull/90))
 - Started documentation at [http://gh.lum.ai/odinson/](http://gh.lum.ai/odinson/) ([#97](https://github.com/lum-ai/odinson/pull/97))
 ### Changed
+- using whole config to create ExtractorEngine and its components (rather than subconfigs) ([#231](https://github.com/lum-ai/odinson/pull/231))
 - removed the MentionFactory, rename OdinMentionsIterator to MentionsIterator ([#228](https://github.com/lum-ai/odinson/pull/228))
 - Different organization for tests. Now every test extends a `BaseSpec` class and there are 6 categories of tests.
 - Turn `State` into a trait with very basic `SqlState` and even more basic `MemoryState` and placeholder `FileState` implementations by [@kwalcock](https://github.com/kwalcock)

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -33,7 +33,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   extends AbstractController(cc) {
   // before testing, we would create configs to pass to the constructor? write test for build like ghp's example
 
-  val extractorEngine: ExtractorEngine = ExtractorEngine.fromConfig(config[Config]("odinson"))
+  val extractorEngine: ExtractorEngine = ExtractorEngine.fromConfig(config)
   val docsDir            = config[File]("odinson.docsDir")
   val DOC_ID_FIELD       = config[String]("odinson.index.documentIdField")
   val SENTENCE_ID_FIELD  = config[String]("odinson.index.sentenceIdField")

--- a/backend/app/utils/OdinsonProviderModule.scala
+++ b/backend/app/utils/OdinsonProviderModule.scala
@@ -12,6 +12,6 @@ class OdinsonProviderModule extends AbstractModule {
   override def configure() {}
 
   @Provides @Singleton
-  def extractorEngineProvider(): ExtractorEngine = ExtractorEngine.fromConfig("odinson")
+  def extractorEngineProvider(): ExtractorEngine = ExtractorEngine.fromConfig()
   
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -76,6 +76,9 @@ odinson {
 
   index {
 
+    # whether to store all the document/sentence fields or not (and so store only the displayField)
+    storeAllFields = false
+
     # the raw token
     rawTokenField = raw
 

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -482,15 +482,31 @@ class ExtractorEngine private (
   }
 
   def getTokensForSpan(m: Mention): Array[String] = {
-    getTokensForSpan(m.luceneDocId, m.odinsonMatch)
+    getTokensForSpan(m.luceneDocId, m.odinsonMatch, displayField)
+  }
+
+  def getTokensForSpan(m: Mention, fieldName: String): Array[String] = {
+    getTokensForSpan(m.luceneDocId, m.odinsonMatch, fieldName)
+  }
+
+  def getTokensForSpan(docID: Int, m: OdinsonMatch): Array[String] = {
+    getTokensForSpan(docID, displayField, m.start, m.end)
+  }
+
+  def getTokensForSpan(docID: Int, m: OdinsonMatch, fieldName: String): Array[String] = {
+    getTokensForSpan(docID, fieldName, m.start, m.end)
+  }
+
+  def getTokensForSpan(docID: Int, start: Int, end: Int): Array[String] = {
+    getTokensForSpan(docID, displayField, start, end)
+  }
+
+  def getTokensForSpan(docID: Int, fieldName: String, start: Int, end: Int): Array[String] = {
+    getTokens(docID, fieldName).slice(start, end)
   }
 
   @deprecated(message = "This signature of getTokens is deprecated and will be removed in a future release. Use getTokensForSpan(docID: Int, m: OdinsonMatch) instead.", since = "https://github.com/lum-ai/odinson/commit/89ceb72095d603cf61d27decc7c42c5eea50c87a")
   def getTokens(docID: Int, m: OdinsonMatch): Array[String] = {
-    getTokens(docID, displayField).slice(m.start, m.end)
-  }
-
-  def getTokensForSpan(docID: Int, m: OdinsonMatch): Array[String] = {
     getTokens(docID, displayField).slice(m.start, m.end)
   }
 
@@ -505,6 +521,7 @@ class ExtractorEngine private (
   def getTokens(docID: Int, fieldName: String): Array[String] = {
     TokenStreamUtils.getTokens(docID, fieldName, indexSearcher, analyzer)
   }
+
 
   /**
     * Close the open resources.

--- a/core/src/main/scala/ai/lum/odinson/OdinsonDocument.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonDocument.scala
@@ -53,7 +53,6 @@ object Sentence {
 
 sealed trait Field {
   def name: String
-  def store: Boolean
   def toJson: String = write(this)
   def toPrettyJson: String = write(this, indent = 4)
 }
@@ -72,7 +71,6 @@ object Field {
 case class TokensField(
   name: String,
   tokens: Seq[String],
-  store: Boolean = false,
 ) extends Field
 
 object TokensField {
@@ -86,7 +84,6 @@ case class GraphField(
   name: String,
   edges: Seq[(Int, Int, String)],
   roots: Set[Int],
-  store: Boolean = false,
 ) extends Field {
 
   def mkIncomingEdges(numTokens: Int): Array[Array[(Int, String)]] = {
@@ -117,7 +114,6 @@ object GraphField {
 case class StringField(
   name: String,
   string: String,
-  store: Boolean = false,
 ) extends Field
 
 object StringField {
@@ -130,7 +126,6 @@ object StringField {
 case class DateField(
   name: String,
   date: String,
-  store: Boolean = false,
 ) extends Field {
   val localDate = LocalDate.parse(date)
 }
@@ -145,11 +140,11 @@ object DateField {
 
   def fromDate(name: String, date: Date, store: Boolean = false): DateField = {
     val localDate = date.toInstant.atZone(ZoneId.systemDefault).toLocalDate
-    fromLocalDate(name, localDate, store)
+    fromLocalDate(name, localDate)
   }
 
   def fromLocalDate(name: String, date: LocalDate, store: Boolean = false): DateField = {
-    DateField(name, date.toString, store)
+    DateField(name, date.toString)
   }
 
 }

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -589,14 +589,14 @@ object QueryCompiler {
 
   def apply(config: Config, vocabulary: Vocabulary): QueryCompiler = {
     new QueryCompiler(
-      config[List[String]]("compiler.allTokenFields"),
-      config[String]("compiler.defaultTokenField"),
-      config[String]("compiler.sentenceLengthField"),
-      config[String]("compiler.dependenciesField"),
-      config[String]("compiler.incomingTokenField"),
-      config[String]("compiler.outgoingTokenField"),
+      config[List[String]]("odinson.compiler.allTokenFields"),
+      config[String]("odinson.compiler.defaultTokenField"),
+      config[String]("odinson.compiler.sentenceLengthField"),
+      config[String]("odinson.compiler.dependenciesField"),
+      config[String]("odinson.compiler.incomingTokenField"),
+      config[String]("odinson.compiler.outgoingTokenField"),
       vocabulary,
-      config[Boolean]("compiler.aggressiveNormalizationToDefaultField")
+      config[Boolean]("odinson.compiler.aggressiveNormalizationToDefaultField")
     )
   }
 

--- a/core/src/main/scala/ai/lum/odinson/lucene/analysis/TokenStreamUtils.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/analysis/TokenStreamUtils.scala
@@ -1,5 +1,7 @@
 package ai.lum.odinson.lucene.analysis
 
+import ai.lum.odinson.utils.exceptions.OdinsonException
+
 import scala.collection.mutable.ArrayBuffer
 import org.apache.lucene.analysis.Analyzer
 import org.apache.lucene.analysis.TokenStream
@@ -17,7 +19,9 @@ object TokenStreamUtils {
   ): Array[String] = {
     val doc = indexSearcher.doc(docID)
     val tvs = indexSearcher.getIndexReader().getTermVectors(docID)
-    val text = doc.getField(fieldName).stringValue
+    val field = doc.getField(fieldName)
+    if (field == null) throw new OdinsonException(s"Attempted to getTokens from field that was not stored: $fieldName")
+    val text = field.stringValue
     val ts = TokenSources.getTokenStream(fieldName, tvs, text, analyzer, -1)
     val tokens = getTokens(ts)
     tokens

--- a/core/src/main/scala/ai/lum/odinson/state/MemoryState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/MemoryState.scala
@@ -91,8 +91,8 @@ object MemoryState {
   case class BaseLabel(docBase: Int, label: String)
 
   def apply(config: Config): MemoryState = {
-    val persistOnClose = config[Boolean]("state.memory.persistOnClose")
-    val saveTo = config.get[File]("state.memory.stateDir")
+    val persistOnClose = config[Boolean]("odinson.state.memory.persistOnClose")
+    val saveTo = config.get[File]("odinson.state.memory.stateDir")
     new MemoryState(persistOnClose, saveTo)
   }
 

--- a/core/src/main/scala/ai/lum/odinson/state/SqlState.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/SqlState.scala
@@ -338,9 +338,9 @@ object SqlState {
   protected var count: AtomicLong = new AtomicLong
 
   def apply(config: Config, indexSearcher: OdinsonIndexSearcher): SqlState = {
-    val persistOnClose = config[Boolean]("state.sql.persistOnClose")
-    val stateFile = config.get[File]("state.sql.persistFile")
-    val jdbcUrl = config[String]("state.sql.url")
+    val persistOnClose = config[Boolean]("odinson.state.sql.persistOnClose")
+    val stateFile = config.get[File]("odinson.state.sql.persistFile")
+    val jdbcUrl = config[String]("odinson.state.sql.url")
     val dataSource: HikariDataSource = {
       val config = new HikariConfig
       config.setJdbcUrl(jdbcUrl)

--- a/core/src/main/scala/ai/lum/odinson/state/State.scala
+++ b/core/src/main/scala/ai/lum/odinson/state/State.scala
@@ -57,7 +57,7 @@ trait State {
 object State {
 
   def apply(config: Config, indexSearcher: OdinsonIndexSearcher): State = {
-    val provider = config[String]("state.provider")
+    val provider = config[String]("odinson.state.provider")
     val state = provider match {
       // The SQL state needs an IndexSearcher to get the docIds from the
       case "sql" => SqlState(config, indexSearcher)

--- a/core/src/test/resources/odinsonDocTest.json
+++ b/core/src/test/resources/odinsonDocTest.json
@@ -1,1 +1,1 @@
-{"id":"foo","metadata":[],"sentences":[{"numTokens":1,"fields":[{"$type":"ai.lum.odinson.TokensField","name":"raw","tokens":["George"],"store":true}]}]}
+{"id":"foo","metadata":[],"sentences":[{"numTokens":1,"fields":[{"$type":"ai.lum.odinson.TokensField","name":"raw","tokens":["George"]}]}]}

--- a/core/src/test/resources/odinsonDocTestPretty.json
+++ b/core/src/test/resources/odinsonDocTestPretty.json
@@ -12,8 +12,7 @@
                     "name": "raw",
                     "tokens": [
                         "George"
-                    ],
-                    "store": true
+                    ]
                 }
             ]
         }

--- a/core/src/test/scala/ai/lum/odinson/TestUtils.scala
+++ b/core/src/test/scala/ai/lum/odinson/TestUtils.scala
@@ -18,7 +18,6 @@ trait BaseFixtures {
 
   object Utils {
     val config = ConfigFactory.load()
-    val odinsonConfig:Config = config[Config]("odinson")
     val rawTokenField = config[String]("odinson.index.rawTokenField")
 
     /**
@@ -39,7 +38,11 @@ trait BaseFixtures {
 
 
     def extractorEngineWithSpecificState(doc: Document, provider: String): ExtractorEngine = {
-      val newConfig = odinsonConfig.withValue("state.provider", ConfigValueFactory.fromAnyRef(provider))
+      extractorEngineWithConfigValue(doc, "odinson.state.provider", provider)
+    }
+
+    def extractorEngineWithConfigValue(doc: Document, key: String, value: String): ExtractorEngine = {
+      val newConfig = config.withValue(key, ConfigValueFactory.fromAnyRef(value))
       mkExtractorEngine(newConfig, doc)
     }
 
@@ -55,7 +58,7 @@ trait BaseFixtures {
     }
 
     def mkExtractorEngine(text: String): ExtractorEngine = {
-      val tokens = TokensField(rawTokenField, text.split(" "), store = true)
+      val tokens = TokensField(rawTokenField, text.split(" "))
       val sentence = Sentence(tokens.tokens.length, Seq(tokens))
       val document = Document("<TEST-ID>", Nil, Seq(sentence))
       mkExtractorEngine(document)

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -36,14 +36,12 @@ class TestOdinsonIndexWriter extends BaseSpec {
 
   def getOdinsonIndexWriter: OdinsonIndexWriter = {
     deleteIndex
-    OdinsonIndexWriter.fromConfig(testConfig.getConfig("odinson"))
+    OdinsonIndexWriter.fromConfig(testConfig)
   }
   
   "OdinsonIndexWriter" should "object should return index from config correctly" in {
     // get index writer
     val indexWriter = getOdinsonIndexWriter
-    // get the directory
-    val directory = indexWriter.directory
     // make sure the folder was created with only the locker inside
     indexWriter.directory.listAll.head should be("write.lock")
     indexWriter.close

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonDocument.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonDocument.scala
@@ -59,8 +59,6 @@ class TestOdinsonDocument extends BaseSpec {
     val tokenField = TokensField.fromJson(field)
     // check if the name is being parsed correct
     tokenField.name should be("chunk")
-    // check if default is there
-    tokenField.store should be(false)
     // test toJson
     tokenField.toJson should equal(field)
     // test pretty
@@ -81,8 +79,6 @@ class TestOdinsonDocument extends BaseSpec {
     // test roots
     graphField.roots shouldBe a[Set[_]]
     graphField.roots.head should equal(1)
-    // test store
-    graphField.store should be(false)
     // test firs and last elements
     graphField.edges.head shouldBe (1, 0, "nsubj")
     graphField.edges.last shouldBe (3, 2, "amod")
@@ -145,7 +141,6 @@ class TestOdinsonDocument extends BaseSpec {
     // parse field
     val stringField = StringField.fromJson(field)
     // check stuff
-    stringField.store shouldBe (false)
     stringField.name shouldBe ("smth")
     stringField.string shouldBe ("smthString")
   }

--- a/core/src/test/scala/ai/lum/odinson/state/TestSqlState.scala
+++ b/core/src/test/scala/ai/lum/odinson/state/TestSqlState.scala
@@ -279,8 +279,8 @@ class TestSqlState extends BaseSpec {
     val filename = "../test.sql"
     val file = new File(filename)
     val config = ExtractorEngine.defaultConfig
-        .withValue("state.sql.persistOnClose", ConfigValueFactory.fromAnyRef(true))
-        .withValue("state.sql.persistFile", ConfigValueFactory.fromAnyRef(filename))
+        .withValue("odinson.state.sql.persistOnClose", ConfigValueFactory.fromAnyRef(true))
+        .withValue("odinson.state.sql.persistFile", ConfigValueFactory.fromAnyRef(filename))
 
     file.delete()
     file.exists should be (false)

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -43,7 +43,7 @@ object IndexDocuments extends App with LazyLogging {
   val synchronizeOrderWithDocumentId =
     config[Boolean]("odinson.index.synchronizeOrderWithDocumentId")
   //
-  val writer = OdinsonIndexWriter.fromConfig(config.getConfig("odinson"))
+  val writer = OdinsonIndexWriter.fromConfig(config)
   val wildcards = Seq("*.json", "*.json.gz")
   logger.info(s"Gathering documents from $docsDir")
   // make this a function

--- a/extra/src/main/scala/ai/lum/odinson/extra/ProcessorsUtils.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/ProcessorsUtils.scala
@@ -47,7 +47,7 @@ object ProcessorsUtils {
 
   /** convert processors sentence to odinson sentence */
   def convertSentence(s: ProcessorsSentence): OdinsonSentence = {
-    val raw = TokensField(rawTokenField, s.raw, store = true)
+    val raw = TokensField(rawTokenField, s.raw)
     val word = TokensField(wordTokenField, s.words)
     val maybeTag = s.tags.map(tags => TokensField(posTagTokenField, tags))
     val maybeLemma = s.lemmas.map(lemmas => TokensField(lemmaTokenField, lemmas))

--- a/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
@@ -46,7 +46,7 @@ object Shell extends App {
   }
   
   // setup searcher
-  val extractorEngine = ExtractorEngine.fromConfig("odinson")
+  val extractorEngine = ExtractorEngine.fromConfig()
 
   // retrieve dependencies
   val dependenciesVocabulary = extractorEngine.compiler.dependenciesVocabulary

--- a/extra/src/test/scala/ai/lum/odinson/extra/TestIndexDocuments.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/TestIndexDocuments.scala
@@ -67,7 +67,7 @@ class TestIndexDocuments extends FlatSpec with Matchers {
       )
 
     // get an ee
-    val ee = ExtractorEngine.fromConfig(config.getConfig("odinson"))
+    val ee = ExtractorEngine.fromConfig(config)
 
 
     // make sure the files are there


### PR DESCRIPTION
added key to config `odinson.storeAllFields`, that when set to `true` will cause the IndexWriter to store all the sentence fields.  This enable you to quickly access various fields for Mentions/Matches, which enables efficient post-processing (e.g., filtering based on content).

Added some additional methods to `ExtractorEngine` to get those tokens.

