### PR TITLE
Token frequency API route for plots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added REST API endpoint for returning frequencies of token-based annotations in a corpus.
 - Added `ai.lum.odinson.utils.TestUtils` and the corresponding `OdinsonText` in the main project for using the test utils in dependent projects ([#232](https://github.com/lum-ai/odinson/pull/231))
 - Added some additional methods to ExtractorEngine to access tokens from diff fields of a Lucene Doc ([#231](https://github.com/lum-ai/odinson/pull/231))
 - Added json serialization and deserialization of Mentions and OdinsonMatches to core ([#226](https://github.com/lum-ai/odinson/pull/226))

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -5,6 +5,8 @@ import java.nio.file.Path
 
 import javax.inject._
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable.Map
 import scala.util.control.NonFatal
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -16,6 +18,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
 import org.apache.lucene.document.{Document => LuceneDocument}
 import org.apache.lucene.search.highlight.TokenSources
+import org.apache.lucene.index.MultiFields
 import com.typesafe.config.ConfigRenderOptions
 import ai.lum.common.ConfigFactory
 import ai.lum.common.ConfigUtils._
@@ -40,7 +43,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   val WORD_TOKEN_FIELD   = config[String]("odinson.displayField")
   val pageSize           = config[Int]("odinson.pageSize")
 
-//  val extractorEngine = opm.extractorEngineProvider()
+  //  val extractorEngine = opm.extractorEngineProvider()
   /** convenience methods for formatting Play 2 Json */
   implicit class JsonOps(json: JsValue) {
     def format(pretty: Option[Boolean]): Result = pretty match {
@@ -63,6 +66,65 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     Ok(extractorEngine.indexReader.numDocs.toString).as(ContentTypes.JSON)
   }
 
+  /**
+    * For a given term field, find the terms ranked min to max (inclusive, 0-indexed)
+
+    * @param field raw, token, lemma, tag, etc.
+    * @param order "freq" for greatest-to least frequency (default), "alpha" for alphanumeric order
+    */
+  def termFreq(field: String, order: Option[String], min: Option[Int], max: Option[Int],
+               scale: Option[String], reverse: Option[Boolean], pretty: Option[Boolean]) = Action.async {
+    Future {
+      // ensure that the requested field exists in the index
+      val fields = MultiFields.getFields(extractorEngine.indexReader)
+      val fieldNames = fields.iterator.asScala.toList
+      // if the field exists, find the frequencies of each term
+      if (fieldNames contains field) {
+        // find the frequency of all terms in this field
+        val terms = fields.terms(field)
+        val termsEnum = terms.iterator()
+        val termFreqs = scala.collection.mutable.HashMap[String, Long]()
+        while (termsEnum.next() != null) {
+          val term = termsEnum.term.utf8ToString
+          termFreqs.update(term, termsEnum.totalTermFreq)
+        }
+
+        // order the resulting frequencies as requested
+        val ordered = order match {
+          // alphabetical
+          case Some("alpha") => termFreqs.toSeq.sortBy { case (term, _) => term }
+          // alphabetical
+          case _ => termFreqs.toSeq.sortBy { case (term, freq) => (-freq, term) }
+        }
+
+        // reverse if necessary
+        val reversed = reverse match {
+          case Some(true) => ordered.reverse
+          case _ => ordered
+        }
+
+        // transform the frequencies as requested
+        val scaled: Seq[(String, Double)] = scale match {
+          case Some("log10") => reversed map { case (term, freq) => (term, math.log10(freq)) }
+          case Some("percent") =>
+            val countTotal = reversed.foldLeft(0.toLong)((s, term) => s + term._2)
+            reversed map { case (term, freq) => (term, freq.toDouble / countTotal)}
+          case _ => reversed.map{ case (term, freq) => (term, freq.toDouble) }
+        }
+
+        // cutoff the results to the requested ranks
+        val defaultMin = 0
+        val defaultMax = 9
+        val res = scaled.slice(min.getOrElse(defaultMin), max.getOrElse(defaultMax) + 1)
+
+        Json.toJson(res.toMap).format(pretty)
+      } else {
+        // the requested field isn't in this index
+        Json.obj().format(pretty)
+      }
+    }
+  }
+
   /** Information about the current corpus. <br>
     * Directory name, num docs, num dependency types, etc.
     */
@@ -73,10 +135,13 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
       val depsVocabSize = {
         loadVocabulary.terms.toSet.size
       }
+      val fields = MultiFields.getFields(extractorEngine.indexReader)
+      val fieldNames = fields.iterator.asScala.toList
       val json = Json.obj(
         "numDocs" -> numDocs,
-        "corpus"   -> corpusDir,
-        "distinctDependencyRelations" -> depsVocabSize
+        "corpus" -> corpusDir,
+        "distinctDependencyRelations" -> depsVocabSize,
+        "fields" -> fieldNames
       )
       json.format(pretty)
     }
@@ -129,10 +194,10 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     * @param label The label to use when committing matches.
     */
   def commitResults(
-    odinsonQuery: String,
-    parentQuery: Option[String],
-    label: String = "Mention"
-  ): Unit = {
+                     odinsonQuery: String,
+                     parentQuery: Option[String],
+                     label: String = "Mention"
+                   ): Unit = {
     val results = parentQuery match {
       case None =>
         val q = extractorEngine.compiler.mkQuery(odinsonQuery)
@@ -145,17 +210,17 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
 
   /**
     * Queries the index.
-    * 
+    *
     * @param odisonQuery An OdinsonQuery
     * @param prevDoc The last Document ID seen on the previous page of results (required if retrieving page 2+).
     * @param prevScore The score of the last Document see on the previous page (required if retrieving page 2+).
     * @return JSON of matches
-  */
+    */
   def retrieveResults(
-    odinsonQuery: OdinsonQuery,
-    prevDoc: Option[Int],
-    prevScore: Option[Float],
-  ): OdinResults = {
+                       odinsonQuery: OdinsonQuery,
+                       prevDoc: Option[Int],
+                       prevScore: Option[Float],
+                     ): OdinResults = {
     (prevDoc, prevScore) match {
       case (Some(doc), Some(score)) =>
         val osd = new OdinsonScoreDoc(doc, score)
@@ -166,12 +231,12 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   case class GrammarRequest(
-    grammar: String,
-    parentQuery: Option[String] = None,
-    pageSize: Option[Int] = None,
-    allowTriggerOverlaps: Option[Boolean] = None,
-    pretty: Option[Boolean] = None
-  )
+                             grammar: String,
+                             parentQuery: Option[String] = None,
+                             pageSize: Option[Int] = None,
+                             allowTriggerOverlaps: Option[Boolean] = None,
+                             pretty: Option[Boolean] = None
+                           )
 
   object GrammarRequest {
     implicit val fmt = Json.format[GrammarRequest]
@@ -181,15 +246,15 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   // import play.api.libs.json.Json
 
   /**
-  * Executes the provided Odinson grammar.
-  * 
-  * @param grammar An Odinson grammar
-  * @param parentQuery A Lucene query to filter documents (optional).
-  * @param pageSize The maximum number of sentences to execute the rules against.
-  * @param allowTriggerOverlaps Whether or not event arguments are permitted to overlap with the event's trigger. 
-  * @return JSON of matches
-  */
-  def executeGrammar() = Action { request => 
+    * Executes the provided Odinson grammar.
+    *
+    * @param grammar An Odinson grammar
+    * @param parentQuery A Lucene query to filter documents (optional).
+    * @param pageSize The maximum number of sentences to execute the rules against.
+    * @param allowTriggerOverlaps Whether or not event arguments are permitted to overlap with the event's trigger.
+    * @return JSON of matches
+    */
+  def executeGrammar() = Action { request =>
     //println(s"body: ${request.body}")
     //val json: JsValue = request.body.asJson.get
     // FIXME: replace .get with validation check
@@ -204,7 +269,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
       // rules -> OdinsonQuery
       val baseExtractors = extractorEngine.ruleReader.compileRuleString(grammar)
       val composedExtractors = parentQuery match {
-        case Some(pq) => 
+        case Some(pq) =>
           val cpq = extractorEngine.compiler.mkParentQuery(pq)
           baseExtractors.map(be => be.copy(query = extractorEngine.compiler.mkQuery(be.query, cpq)))
         case None => baseExtractors
@@ -221,7 +286,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
         val iterator = extractorEngine.extractMentions(composedExtractors, numSentences = maxSentences, allowTriggerOverlaps = allowTriggerOverlaps, disableMatchSelector = false)
         iterator.toVector
       }
-      
+
       val duration = (System.currentTimeMillis() - start) / 1000f // duration in seconds
 
       val json = Json.toJson(mkJson(parentQuery, duration, allowTriggerOverlaps, mentions))
@@ -245,23 +310,23 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     * @return JSON of matches
     */
   def runQuery(
-    odinsonQuery: String,
-    parentQuery: Option[String],
-    label: Option[String], // FIXME: in the future, this will be decided in the grammar
-    commit: Option[Boolean], // FIXME: in the future, this will be decided in the grammar
-    prevDoc: Option[Int],
-    prevScore: Option[Float],
-    enriched: Boolean,
-    pretty: Option[Boolean]
-  ) = Action.async {
+                odinsonQuery: String,
+                parentQuery: Option[String],
+                label: Option[String], // FIXME: in the future, this will be decided in the grammar
+                commit: Option[Boolean], // FIXME: in the future, this will be decided in the grammar
+                prevDoc: Option[Int],
+                prevScore: Option[Float],
+                enriched: Boolean,
+                pretty: Option[Boolean]
+              ) = Action.async {
     Future {
       try {
-       val oq = parentQuery match {
-          case Some(pq) => 
+        val oq = parentQuery match {
+          case Some(pq) =>
             extractorEngine.compiler.mkQuery(odinsonQuery, pq)
           case None =>
             extractorEngine.compiler.mkQuery(odinsonQuery)
-       }
+        }
         val start = System.currentTimeMillis()
         val results: OdinResults = retrieveResults(oq, prevDoc, prevScore)
         val duration = (System.currentTimeMillis() - start) / 1000f // duration in seconds
@@ -288,9 +353,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getMetadataJsonByDocumentId(
-    documentId: String, 
-    pretty: Option[Boolean]
-  ) = Action.async {
+                                   documentId: String,
+                                   pretty: Option[Boolean]
+                                 ) = Action.async {
     Future {
       try {
         val od: OdinsonDocument = loadParentDocByDocumentId(documentId)
@@ -306,9 +371,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getMetadataJsonBySentenceId(
-    sentenceId: Int,
-    pretty: Option[Boolean]
-  ) = Action.async {
+                                   sentenceId: Int,
+                                   pretty: Option[Boolean]
+                                 ) = Action.async {
     Future {
       try {
         val luceneDoc: LuceneDocument = extractorEngine.indexReader.document(sentenceId)
@@ -326,9 +391,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getParentDocJsonBySentenceId(
-    sentenceId: Int, 
-    pretty: Option[Boolean]
-  ) = Action.async {
+                                    sentenceId: Int,
+                                    pretty: Option[Boolean]
+                                  ) = Action.async {
     Future {
       try {
         val luceneDoc: LuceneDocument = extractorEngine.indexReader.document(sentenceId)
@@ -346,9 +411,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getParentDocJsonByDocumentId(
-    documentId: String, 
-    pretty: Option[Boolean]
-  ) = Action.async {
+                                    documentId: String,
+                                    pretty: Option[Boolean]
+                                  ) = Action.async {
     Future {
       try {
         val odinsonDoc = loadParentDocByDocumentId(documentId)
@@ -364,12 +429,12 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def mkJson(
-    odinsonQuery: String, 
-    parentQuery: Option[String], 
-    duration: Float, 
-    results: OdinResults, 
-    enriched: Boolean
-  ): JsValue = {
+              odinsonQuery: String,
+              parentQuery: Option[String],
+              duration: Float,
+              results: OdinResults,
+              enriched: Boolean
+            ): JsValue = {
 
     val scoreDocs: JsValue = enriched match {
       case true  => Json.arr(results.scoreDocs.map(mkJsonWithEnrichedResponse):_*)
@@ -387,11 +452,11 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
 
   /** Process results from executeGrammar */
   def mkJson(
-    parentQuery: Option[String], 
-    duration: Float, 
-    allowTriggerOverlaps: Boolean, 
-    mentions: Seq[Mention]
-  ): JsValue = {
+              parentQuery: Option[String],
+              duration: Float,
+              allowTriggerOverlaps: Boolean,
+              mentions: Seq[Mention]
+            ): JsValue = {
 
     val mentionsJson: JsValue = Json.arr(mentions.map(mkJson):_*)
 
@@ -402,7 +467,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
       "mentions"    -> mentionsJson
     )
   }
-  
+
   def mkJson(mention: Mention): Json.JsValueWrapper = {
     //val doc: LuceneDocument = extractorEngine.indexSearcher.doc(mention.luceneDocId)
     // We want **all** tokens for the sentence

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -194,10 +194,10 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     * @param label The label to use when committing matches.
     */
   def commitResults(
-                     odinsonQuery: String,
-                     parentQuery: Option[String],
-                     label: String = "Mention"
-                   ): Unit = {
+    odinsonQuery: String,
+    parentQuery: Option[String],
+    label: String = "Mention"
+  ): Unit = {
     val results = parentQuery match {
       case None =>
         val q = extractorEngine.compiler.mkQuery(odinsonQuery)
@@ -217,10 +217,10 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     * @return JSON of matches
     */
   def retrieveResults(
-                       odinsonQuery: OdinsonQuery,
-                       prevDoc: Option[Int],
-                       prevScore: Option[Float],
-                     ): OdinResults = {
+    odinsonQuery: OdinsonQuery,
+    prevDoc: Option[Int],
+    prevScore: Option[Float],
+  ): OdinResults = {
     (prevDoc, prevScore) match {
       case (Some(doc), Some(score)) =>
         val osd = new OdinsonScoreDoc(doc, score)
@@ -231,12 +231,12 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   case class GrammarRequest(
-                             grammar: String,
-                             parentQuery: Option[String] = None,
-                             pageSize: Option[Int] = None,
-                             allowTriggerOverlaps: Option[Boolean] = None,
-                             pretty: Option[Boolean] = None
-                           )
+    grammar: String,
+    parentQuery: Option[String] = None,
+    pageSize: Option[Int] = None,
+    allowTriggerOverlaps: Option[Boolean] = None,
+    pretty: Option[Boolean] = None
+  )
 
   object GrammarRequest {
     implicit val fmt = Json.format[GrammarRequest]
@@ -310,15 +310,15 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
     * @return JSON of matches
     */
   def runQuery(
-                odinsonQuery: String,
-                parentQuery: Option[String],
-                label: Option[String], // FIXME: in the future, this will be decided in the grammar
-                commit: Option[Boolean], // FIXME: in the future, this will be decided in the grammar
-                prevDoc: Option[Int],
-                prevScore: Option[Float],
-                enriched: Boolean,
-                pretty: Option[Boolean]
-              ) = Action.async {
+    odinsonQuery: String,
+    parentQuery: Option[String],
+    label: Option[String], // FIXME: in the future, this will be decided in the grammar
+    commit: Option[Boolean], // FIXME: in the future, this will be decided in the grammar
+    prevDoc: Option[Int],
+    prevScore: Option[Float],
+    enriched: Boolean,
+    pretty: Option[Boolean]
+  ) = Action.async {
     Future {
       try {
         val oq = parentQuery match {
@@ -353,9 +353,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getMetadataJsonByDocumentId(
-                                   documentId: String,
-                                   pretty: Option[Boolean]
-                                 ) = Action.async {
+    documentId: String,
+    pretty: Option[Boolean]
+  ) = Action.async {
     Future {
       try {
         val od: OdinsonDocument = loadParentDocByDocumentId(documentId)
@@ -371,9 +371,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getMetadataJsonBySentenceId(
-                                   sentenceId: Int,
-                                   pretty: Option[Boolean]
-                                 ) = Action.async {
+    sentenceId: Int,
+    pretty: Option[Boolean]
+  ) = Action.async {
     Future {
       try {
         val luceneDoc: LuceneDocument = extractorEngine.indexReader.document(sentenceId)
@@ -391,9 +391,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getParentDocJsonBySentenceId(
-                                    sentenceId: Int,
-                                    pretty: Option[Boolean]
-                                  ) = Action.async {
+    sentenceId: Int,
+    pretty: Option[Boolean]
+  ) = Action.async {
     Future {
       try {
         val luceneDoc: LuceneDocument = extractorEngine.indexReader.document(sentenceId)
@@ -411,9 +411,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def getParentDocJsonByDocumentId(
-                                    documentId: String,
-                                    pretty: Option[Boolean]
-                                  ) = Action.async {
+    documentId: String,
+    pretty: Option[Boolean]
+  ) = Action.async {
     Future {
       try {
         val odinsonDoc = loadParentDocByDocumentId(documentId)
@@ -429,12 +429,12 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   }
 
   def mkJson(
-              odinsonQuery: String,
-              parentQuery: Option[String],
-              duration: Float,
-              results: OdinResults,
-              enriched: Boolean
-            ): JsValue = {
+    odinsonQuery: String,
+    parentQuery: Option[String],
+    duration: Float,
+    results: OdinResults,
+    enriched: Boolean
+  ): JsValue = {
 
     val scoreDocs: JsValue = enriched match {
       case true  => Json.arr(results.scoreDocs.map(mkJsonWithEnrichedResponse):_*)
@@ -452,11 +452,11 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
 
   /** Process results from executeGrammar */
   def mkJson(
-              parentQuery: Option[String],
-              duration: Float,
-              allowTriggerOverlaps: Boolean,
-              mentions: Seq[Mention]
-            ): JsValue = {
+    parentQuery: Option[String],
+    duration: Float,
+    allowTriggerOverlaps: Boolean,
+    mentions: Seq[Mention]
+  ): JsValue = {
 
     val mentionsJson: JsValue = Json.arr(mentions.map(mkJson):_*)
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -18,21 +18,22 @@ POST    /api/execute/grammar            controllers.OdinsonController.executeGra
 #GET    /api/execute/grammar            controllers.OdinsonController.executeGrammar(grammar: String, parentQuery: Option[String], pageSize: Option[Int], allowTriggerOverlaps: Boolean, pretty: Option[Boolean])
 
 # parent doc
-GET     /api/parent/by-document-id                    controllers.OdinsonController.getParentDocJsonByDocumentId(documentId: String, pretty: Option[Boolean])
-GET     /api/parent/by-sentence-id                    controllers.OdinsonController.getParentDocJsonBySentenceId(sentenceId: Int, pretty: Option[Boolean])
+GET     /api/parent/by-document-id      controllers.OdinsonController.getParentDocJsonByDocumentId(documentId: String, pretty: Option[Boolean])
+GET     /api/parent/by-sentence-id      controllers.OdinsonController.getParentDocJsonBySentenceId(sentenceId: Int, pretty: Option[Boolean])
 
 # metadata
-GET     /api/metadata/by-document-id                    controllers.OdinsonController.getMetadataJsonByDocumentId(documentId: String, pretty: Option[Boolean])
-GET     /api/metadata/by-sentence-id                    controllers.OdinsonController.getMetadataJsonBySentenceId(sentenceId: Int, pretty: Option[Boolean])
+GET     /api/metadata/by-document-id    controllers.OdinsonController.getMetadataJsonByDocumentId(documentId: String, pretty: Option[Boolean])
+GET     /api/metadata/by-sentence-id    controllers.OdinsonController.getMetadataJsonBySentenceId(sentenceId: Int, pretty: Option[Boolean])
 
 # sentence json
 GET     /api/sentence                   controllers.OdinsonController.sentenceJsonForSentId(sentenceId: Int, pretty: Option[Boolean])
 
 # counts
 GET     /api/numdocs                    controllers.OdinsonController.numDocs
+GET     /api/term-freq                  controllers.OdinsonController.termFreq(field: String, order: Option[String], min: Option[Int], max: Option[Int], scale: Option[String], reverse: Option[Boolean], pretty: Option[Boolean])
 
 # corpus info and statistics
-GET     /api/corpus                    controllers.OdinsonController.corpusInfo(pretty: Option[Boolean])
+GET     /api/corpus                     controllers.OdinsonController.corpusInfo(pretty: Option[Boolean])
 
 # misc
 GET     /api/dependencies-vocabulary    controllers.OdinsonController.dependenciesVocabulary(pretty: Option[Boolean])

--- a/backend/public/schema/odinson.yaml
+++ b/backend/public/schema/odinson.yaml
@@ -290,6 +290,82 @@ paths:
                 format: int32
                 example: 10000
 
+  /api/term-freq:
+    get:
+      tags:
+        - statistics
+      summary: |
+        Retrieves the frequencies of token annotations such as word and lemma counts.
+      description: |
+        Retrieves the frequencies of token annotations such as word and lemma counts.
+      operationId: term-freq
+      parameters:
+        - name: field
+          in: query
+          description: |
+            The token field (e.g., word, lemma) whose frequencies are to be counted.
+          required: true
+          schema:
+            type: string
+            example: tag
+        - name: order
+          in: query
+          description: |
+            The order in which to return results: "alpha" or "freq" (default).
+          required: false
+          schema:
+            type: string
+            example: freq
+        - name: min
+          in: query
+          description: |
+            The smallest rank to return, with 0 (default) being the highest ranked.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 0
+        - name: max
+          in: query
+          description: |
+            The highest rank to return, e.g. 9 (default).
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 9
+        - name: scale
+          in: query
+          description: |
+            Scaling to apply to frequency counts. Choices are "count" (default), "log10", and "percent".
+          required: false
+          schema:
+            type: string
+            example: count
+        - name: reverse
+          in: query
+          description: |
+            Whether to reverse the rank order, to select the 10 lease frequent results, for example.
+          required: false
+          schema:
+            type: boolean
+        - name: pretty
+          in: query
+          description: |
+            Whether or not to pretty print the response.
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Frequencies of token annotations such as word and lemma counts.
+          content:
+             application/json:
+               schema:
+                 type: array
+                 items:
+                   $ref: '#/components/schemas/TermFrequency'
+
   # /api/most-common:
   #   get:
   #     tags:
@@ -559,6 +635,22 @@ components:
           format: float
           description: The similarity score for the returned term.
           example: 0.673
+
+    TermFrequency:
+      type: object
+      required:
+        - term
+        - frequency
+      properties:
+        term:
+          type: string
+          description: A term in a token field.
+          example: NNPS
+        frequency:
+          type: number
+          format: float
+          description: The number of occurrences of the term (potentially scaled).
+          example: 104291.0
 
     # MatchFrequency:
     #   type: object

--- a/backend/test/controllers/OdinsonControllerSpec.scala
+++ b/backend/test/controllers/OdinsonControllerSpec.scala
@@ -178,6 +178,16 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
     }
 
+    "respond with token-based frequencies using the /term-freq endpoint" in {
+      val body = Json.obj("field" -> "word")
+
+      val response = route(app, FakeRequest(GET, "/api/term-freq?field=word").withJsonBody(body)).get
+
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+      println(Helpers.contentAsString(response))
+    }
+
   }
 
 


### PR DESCRIPTION
This pull request enables a new API call, `termFreq`, which can return counts, percentage-of-corpus, or log-transformed counts for any token field in the index. You can now retrieve the available fields through `corpusInfo` to make this less error-prone. You can also specify a min and max rank for the request, and order by alphanumeric order or by frequency (with an option to reverse).