### PR TITLE
Verbose json options and require displayField in storedFields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.3.0] - 2021-02-18
 ### Added
+- Added ability to serialize Mentions verbosely (with displayField or all storedFields) ([#265](https://github.com/lum-ai/odinson/pull/265))
 - Added project-wide formatting settings and a PR check for linting
 - Added a file that accompanies index (`settings.json`) that describes settings used in creating the index.  Currently storing `storedFields`. ([#255](https://github.com/lum-ai/odinson/pull/255))
 - Added REST API endpoint for returning frequencies of token-based annotations in a corpus.
@@ -36,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Put indexing docs in a method to be used by external projects. ([#90](https://github.com/lum-ai/odinson/pull/90))
 - Started documentation at [http://gh.lum.ai/odinson/](http://gh.lum.ai/odinson/) ([#97](https://github.com/lum-ai/odinson/pull/97))
 ### Changed
+- JsonSerializer is now a class, and has the ability to serialize verbose detail about Mentions ([#265](https://github.com/lum-ai/odinson/pull/265))
 - updated version of CluLab processors in `extra/` to 8.2.3 ([#241](https://github.com/lum-ai/odinson/pull/241))
 - using whole config to create ExtractorEngine and its components (rather than subconfigs) ([#231](https://github.com/lum-ai/odinson/pull/231))
 - removed the MentionFactory, rename OdinMentionsIterator to MentionsIterator ([#228](https://github.com/lum-ai/odinson/pull/228))

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -76,8 +76,8 @@ odinson {
 
   index {
 
-    # list of document/sentence fields to store in index **in addition to** the displayField
-    storedFields = []
+    # list of document/sentence fields to store in index, **must** include the displayField
+    storedFields = [${odinson.displayField}]
 
     # the raw token
     rawTokenField = raw

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -21,7 +21,7 @@ import ai.lum.odinson.lucene.analysis.TokenStreamUtils
 import ai.lum.odinson.lucene.search._
 import ai.lum.odinson.state.{ MockState, State }
 import ai.lum.odinson.digraph.Vocabulary
-import ai.lum.odinson.utils.MostRecentlyUsed
+import ai.lum.odinson.utils.{ IndexSettings, MostRecentlyUsed }
 import ai.lum.odinson.utils.exceptions.OdinsonException
 
 import scala.collection.mutable.ArrayBuffer
@@ -30,6 +30,7 @@ class ExtractorEngine private (
   val indexSearcher: OdinsonIndexSearcher,
   val compiler: QueryCompiler,
   val displayField: String,
+  val indexSettings: IndexSettings,
   val state: State, // todo: should this be private?
   val parentDocIdField: String
 ) {
@@ -629,6 +630,7 @@ object ExtractorEngine {
     val displayField = config[String]("odinson.displayField")
     val indexSearcher = new OdinsonIndexSearcher(indexReader, computeTotalHits)
     val vocabulary = Vocabulary.fromDirectory(indexDir)
+    val indexSettings = IndexSettings.fromDirectory(indexDir)
     val compiler = QueryCompiler(config, vocabulary)
     val state = State(config, indexSearcher)
     val parentDocIdField = config[String]("odinson.index.documentIdField")
@@ -636,6 +638,7 @@ object ExtractorEngine {
       indexSearcher,
       compiler,
       displayField,
+      indexSettings,
       state,
       parentDocIdField
     )

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -23,6 +23,7 @@ import ai.lum.odinson.lucene.analysis._
 import ai.lum.odinson.digraph.{ DirectedGraph, Vocabulary }
 import ai.lum.odinson.serialization.UnsafeSerializer
 import ai.lum.odinson.utils.IndexSettings
+import ai.lum.odinson.utils.exceptions.OdinsonException
 
 class OdinsonIndexWriter(
   val directory: Directory,
@@ -281,7 +282,10 @@ object OdinsonIndexWriter {
         (dir, vocab)
     }
     // Always store the display field, also store these additional fields
-    val settings = IndexSettings(Seq(displayField) ++ storedFields)
+    if (!storedFields.contains(displayField)) {
+      throw new OdinsonException("`odinson.index.storedFields` must contain `odinson.displayField`")
+    }
+    val settings = IndexSettings(storedFields)
     new OdinsonIndexWriter(
       directory,
       vocabulary,

--- a/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
+++ b/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
@@ -5,7 +5,11 @@ import ai.lum.odinson.serialization.JsonSerializer._
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import ujson.Value
 
-class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[ExtractorEngine] = None) {
+class JsonSerializer(
+  verbose: String = NONE,
+  indent: Int = 4,
+  engine: Option[ExtractorEngine] = None
+) {
 
   // Ensure a valid verbosity level and compatible engine
   checkVerbosity(verbose)
@@ -36,7 +40,6 @@ class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[Ext
   def asJsonString(m: Mention): String = {
     ujson.write(asJsonValue(m))
   }
-
 
   // Json Lines (one mention json per line)
 
@@ -73,12 +76,14 @@ class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[Ext
       "docId" -> corpusDocId,
       "sentId" -> corpusSentId,
       "foundBy" -> m.foundBy,
-      "arguments" -> asJsonValue(m.arguments),
+      "arguments" -> asJsonValue(m.arguments)
     )
 
     // Add verbose content if requested
     if (verbose != NONE) {
-      if (engine == null) throw new OdinsonException("Cannot use verbose serialization without giving an extractor engine.")
+      if (engine == null) throw new OdinsonException(
+        "Cannot use verbose serialization without giving an extractor engine."
+      )
       json("detail") = mkVerboseContent(m)
     }
 
@@ -193,9 +198,9 @@ class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[Ext
     // Note that since we already checked the validity of verbose and engine,
     // calling `get` here on the engine should not be a problem.
     val fieldsToInclude = verbose match {
-      case NONE => Seq.empty
+      case NONE    => Seq.empty
       case DISPLAY => Seq(engine.get.displayField)
-      case ALL => engine.get.indexSettings.storedFields
+      case ALL     => engine.get.indexSettings.storedFields
     }
 
     // Retrieve the tokens for each included field
@@ -206,7 +211,6 @@ class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[Ext
 
     json
   }
-
 
   def stringOrNull(s: Option[String]): Value = {
     if (s.isDefined) ujson.Str(s.get)
@@ -380,22 +384,26 @@ class JsonSerializer(verbose: String = NONE, indent: Int = 4, engine: Option[Ext
 
   def checkVerbosity(verbose: String): Unit = {
     if (!validVerbose.contains(verbose)) {
-      throw new OdinsonException(s"Invalid setting for `verbose`: $verbose [valid: ${validVerbose.mkString(", ")}]")
+      throw new OdinsonException(
+        s"Invalid setting for `verbose`: $verbose [valid: ${validVerbose.mkString(", ")}]"
+      )
     }
   }
 
- def checkEngine(verbose: String, engine: Option[ExtractorEngine]): Unit = {
-   if (verbose != NONE && engine.isEmpty) {
-     throw new OdinsonException("Cannot request verbose serialization without providing an ExtractorEngine.")
-   }
- }
+  def checkEngine(verbose: String, engine: Option[ExtractorEngine]): Unit = {
+    if (verbose != NONE && engine.isEmpty) {
+      throw new OdinsonException(
+        "Cannot request verbose serialization without providing an ExtractorEngine."
+      )
+    }
+  }
+
 }
 
-object JsonSerializer{
+object JsonSerializer {
   val NONE = "none"
   val DISPLAY = "display"
   val ALL = "all"
   val validVerbose = Seq(NONE, DISPLAY, ALL)
-
 
 }

--- a/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
+++ b/core/src/main/scala/ai/lum/odinson/serialization/JsonSerializer.scala
@@ -189,20 +189,24 @@ class JsonSerializer(
 
   private def mkVerboseContent(m: Mention): Value = {
     val json = ujson.Obj()
+    json("mention") = ujson.Obj()
+    json("document") = ujson.Obj()
 
     // Determine which fields to include, given the specified level of verbosity
     // Note that since we already checked the validity of verbose and engine,
     // calling `get` here on the engine should not be a problem.
     val fieldsToInclude = verbose match {
-      case VerboseLevels.Minimal  => Seq.empty
-      case VerboseLevels.Display  => Seq(engine.get.displayField)
-      case VerboseLevels.All      => engine.get.indexSettings.storedFields
+      case VerboseLevels.Minimal => Seq.empty
+      case VerboseLevels.Display => Seq(engine.get.displayField)
+      case VerboseLevels.All     => engine.get.indexSettings.storedFields
     }
 
     // Retrieve the tokens for each included field
     for (field <- fieldsToInclude) {
-      val tokens = engine.get.getTokensForSpan(m, field)
-      json(field) = tokens.toSeq
+      val mentionTokens = engine.get.getTokensForSpan(m, field)
+      json("mention")(field) = mentionTokens.toSeq
+      val documentTokens = engine.get.getTokens(m.luceneDocId, field)
+      json("document")(field) = documentTokens.toSeq
     }
 
     json
@@ -400,6 +404,5 @@ object JsonSerializer {
     val Minimal, Display, All = Value
 
   }
-
 
 }

--- a/core/src/test/resources/serialization.yml
+++ b/core/src/test/resources/serialization.yml
@@ -75,3 +75,10 @@ rules:
     type: basic
     pattern: |
       (?<name> Rainbows)
+
+  - name: MultipleWords
+    label: MultipleWordsLabel
+    priority: 1
+    type: basic
+    pattern: |
+      [word=/Rainbows|shine|bright/]{1,3}

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestExtractorEngine.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestExtractorEngine.scala
@@ -31,7 +31,7 @@ class TestExtractorEngine extends OdinsonTest {
   it should "getTokensFromSpan correctly from existing Field" in {
     // Becky ate gummy bears.
     val doc = getDocument("becky-gummy-bears-v2")
-    val ee = extractorEngineWithConfigValue(doc, "odinson.index.storedFields", Seq("lemma"))
+    val ee = extractorEngineWithConfigValue(doc, "odinson.index.storedFields", Seq("raw", "lemma"))
     val rules = """
         |rules:
         |  - name: testrule
@@ -62,7 +62,7 @@ class TestExtractorEngine extends OdinsonTest {
   it should "getTokensFromSpan with OdinsonException from non-existing Field" in {
     // Becky ate gummy bears.
     val doc = getDocument("becky-gummy-bears-v2")
-    val ee = extractorEngineWithConfigValue(doc, "odinson.index.storeAllFields", "true")
+    val ee = extractorEngineWithConfigValue(doc, "odinson.index.storedFields", Seq("raw", "lemma"))
     val rules = """
       |rules:
       |  - name: testrule

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -97,7 +97,7 @@ class TestOdinsonIndexWriter extends OdinsonTest {
         .withValue("odinson.indexDir", ConfigValueFactory.fromAnyRef(indexFile.getAbsolutePath))
         .withValue(
           "odinson.index.storedFields",
-          ConfigValueFactory.fromAnyRef(Seq("apple", "banana", "kiwi").asJava)
+          ConfigValueFactory.fromAnyRef(Seq("apple", "banana", "kiwi", "raw").asJava)
         )
     }
 
@@ -117,7 +117,10 @@ class TestOdinsonIndexWriter extends OdinsonTest {
 
     val doc = getDocument("rainbows")
     val customConfig: Config = defaultConfig
-      .withValue("odinson.index.storedFields", ConfigValueFactory.fromAnyRef(Seq("tag").asJava))
+      .withValue(
+        "odinson.index.storedFields",
+        ConfigValueFactory.fromAnyRef(Seq("tag", "raw").asJava)
+      )
     def ee = mkExtractorEngine(customConfig, doc)
 
     // we asked it to store `tag` so the extractor engine should be able to access the content
@@ -126,5 +129,20 @@ class TestOdinsonIndexWriter extends OdinsonTest {
     // be able to retrieve the content
     an[OdinsonException] should be thrownBy ee.getTokensForSpan(0, "entity", 0, 1)
 
+  }
+
+  it should "throw an exception if the displayField isn't in the storedFields" in {
+    val indexFile = new File(tmpFolder, "index2")
+    val customConfig: Config = {
+      testConfig
+        // re-compute the index and docs path's
+        .withValue("odinson.indexDir", ConfigValueFactory.fromAnyRef(indexFile.getAbsolutePath))
+        .withValue(
+          "odinson.index.storedFields",
+          ConfigValueFactory.fromAnyRef(Seq("apple", "banana", "kiwi").asJava)
+        )
+    }
+
+    an[OdinsonException] shouldBe thrownBy { OdinsonIndexWriter.fromConfig(customConfig) }
   }
 }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonTest.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonTest.scala
@@ -14,6 +14,9 @@ import ai.lum.odinson.{
 }
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
+import com.typesafe.config.ConfigValueFactory
+
+import scala.collection.JavaConverters.asJavaIterableConverter
 
 class TestOdinsonTest extends OdinsonTest {
 
@@ -47,7 +50,16 @@ class TestOdinsonTest extends OdinsonTest {
     eeSQL.state shouldBe a[SqlState]
 
     //def extractorEngineWithConfigValue(doc: Document, key: String, value: String): ExtractorEngine = {
-    val eeFoobar = extractorEngineWithConfigValue(doc, "odinson.displayField", "foobar")
+    val eeFoobar = mkExtractorEngine(
+      defaultConfig
+        .withValue("odinson.displayField", ConfigValueFactory.fromAnyRef("foobar"))
+        // The displayField is required to be in the storedFields
+        .withValue(
+          "odinson.index.storedFields",
+          ConfigValueFactory.fromAnyRef(Seq("foobar").asJava)
+        ),
+      doc
+    )
     eeFoobar.displayField should equal("foobar")
   }
 

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -247,7 +247,7 @@ class TestJsonSerialization extends OdinsonTest {
     raw should contain inOrderOnly ("Rainbows", "shine", "bright")
     val docRaw = detail("document")("raw").arr.map(_.str)
     docRaw.mkString(" ") shouldBe "Rainbows shine bright bright bright ."
-    
+
     a[java.util.NoSuchElementException] should be thrownBy json("lemma")
   }
 

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -11,8 +11,12 @@ class TestJsonSerialization extends OdinsonTest {
   val doc = getDocument("rainbows")
   val engine = mkExtractorEngine(doc)
   val storedFields = util.Arrays.asList("raw", "lemma", "tag")
+
   val verboseEngine = mkExtractorEngine(
-    defaultConfig.withValue("odinson.index.storedFields", ConfigValueFactory.fromIterable(storedFields)),
+    defaultConfig.withValue(
+      "odinson.index.storedFields",
+      ConfigValueFactory.fromIterable(storedFields)
+    ),
     doc
   )
 
@@ -20,9 +24,15 @@ class TestJsonSerialization extends OdinsonTest {
 
   // Without state
   val mentions = engine.extractNoState(extractors).toArray
-  val jsonSerializer = new JsonSerializer(verbose = JsonSerializer.NONE, indent = 4, engine = Some(engine))
-  val displaySerializer = new JsonSerializer(verbose = JsonSerializer.DISPLAY, indent = 4, engine = Some(verboseEngine))
-  val allSerializer = new JsonSerializer(verbose = JsonSerializer.ALL, indent = 4, engine = Some(verboseEngine))
+
+  val jsonSerializer =
+    new JsonSerializer(verbose = JsonSerializer.NONE, indent = 4, engine = Some(engine))
+
+  val displaySerializer =
+    new JsonSerializer(verbose = JsonSerializer.DISPLAY, indent = 4, engine = Some(verboseEngine))
+
+  val allSerializer =
+    new JsonSerializer(verbose = JsonSerializer.ALL, indent = 4, engine = Some(verboseEngine))
 
   "JsonSerializer" should "handle NGramMentions" in {
     val m = getSingleMentionFromRule(mentions, "NGram")
@@ -235,7 +245,7 @@ class TestJsonSerialization extends OdinsonTest {
     val raw = detail("raw").arr.map(_.str)
     raw should contain inOrderOnly ("Rainbows", "shine", "bright")
 
-    a [java.util.NoSuchElementException] should be thrownBy json("lemma")
+    a[java.util.NoSuchElementException] should be thrownBy json("lemma")
   }
 
   "JsonSerializer with verbose=all" should "include the all stored fields and content" in {
@@ -247,7 +257,7 @@ class TestJsonSerialization extends OdinsonTest {
     detail("lemma").arr.map(_.str) should contain inOrderOnly ("rainbow", "shine", "bright")
     detail("tag").arr.map(_.str) should contain inOrderOnly ("NNS", "VBP", "JJ")
 
-    a [java.util.NoSuchElementException] should be thrownBy json("watermelon")
+    a[java.util.NoSuchElementException] should be thrownBy json("watermelon")
   }
 
 }

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -1,21 +1,33 @@
 package ai.lum.odinson.serialization
 
+import java.util
+
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
+import ai.lum.odinson.utils.exceptions.OdinsonException
+import com.typesafe.config.ConfigValueFactory
 
 class TestJsonSerialization extends OdinsonTest {
 
   val doc = getDocument("rainbows")
   val engine = mkExtractorEngine(doc)
+  val storedFields = util.Arrays.asList("raw", "lemma", "tag")
+  val verboseEngine = mkExtractorEngine(
+    defaultConfig.withValue("odinson.index.storedFields", ConfigValueFactory.fromIterable(storedFields)),
+    doc
+  )
 
   val extractors = engine.compileRuleResource("/serialization.yml")
 
   // Without state
   val mentions = engine.extractNoState(extractors).toArray
+  val jsonSerializer = new JsonSerializer(verbose = JsonSerializer.NONE, indent = 4, engine = Some(engine))
+  val displaySerializer = new JsonSerializer(verbose = JsonSerializer.DISPLAY, indent = 4, engine = Some(verboseEngine))
+  val allSerializer = new JsonSerializer(verbose = JsonSerializer.ALL, indent = 4, engine = Some(verboseEngine))
 
   "JsonSerializer" should "handle NGramMentions" in {
     val m = getSingleMentionFromRule(mentions, "NGram")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -23,8 +35,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle basic EventMatches" in {
     val m = getSingleMentionFromRule(mentions, "Event")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -32,8 +44,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle EventMatches with arg quantifiers" in {
     val m = getSingleMentionFromRule(mentions, "Event-plus")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -41,8 +53,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle EventMatches with arg ranges" in {
     val m = getSingleMentionFromRule(mentions, "Event-3")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -50,8 +62,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle GraphTraversals" in {
     val m = getSingleMentionFromRule(mentions, "GraphTraversal")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -59,8 +71,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Repetition" in {
     val m = getSingleMentionFromRule(mentions, "Repetition")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -68,8 +80,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Repetition (lazy)" in {
     val m = getSingleMentionFromRule(mentions, "Repetition-lazy")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -77,8 +89,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Optional" in {
     val m = getSingleMentionFromRule(mentions, "Optional")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -86,8 +98,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Or" in {
     val m = getSingleMentionFromRule(mentions, "Or")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -95,8 +107,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Named" in {
     val m = getSingleMentionFromRule(mentions, "Named")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -107,8 +119,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   "JsonSerializer" should "handle NGramMentions with State" in {
     val m = getSingleMentionFromRule(stateMentions, "NGram")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -116,8 +128,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle basic EventMatches with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Event")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -125,8 +137,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle EventMatches with arg quantifiers with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Event-plus")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -134,8 +146,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle EventMatches with arg ranges with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Event-3")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -143,8 +155,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle GraphTraversals with State" in {
     val m = getSingleMentionFromRule(stateMentions, "GraphTraversal")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -152,8 +164,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Repetition with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Repetition")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -161,8 +173,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Repetition (lazy) with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Repetition-lazy")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -170,8 +182,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Optional with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Optional")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -179,8 +191,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Or with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Or")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -188,8 +200,8 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "handle Named with State" in {
     val m = getSingleMentionFromRule(stateMentions, "Named")
-    val json = JsonSerializer.asJsonValue(Array(m))
-    val reconstituted = JsonSerializer.deserializeMentions(json)
+    val json = jsonSerializer.asJsonValue(Array(m))
+    val reconstituted = jsonSerializer.deserializeMentions(json)
     reconstituted should have length (1)
 
     mentionsShouldBeEqual(m, reconstituted.head) should be(true)
@@ -197,23 +209,45 @@ class TestJsonSerialization extends OdinsonTest {
 
   it should "properly serialize and deserialized using json strings" in {
     val m = getSingleMentionFromRule(stateMentions, "Or")
-    val jsonString = JsonSerializer.asJsonString(m)
-    val deserialized = JsonSerializer.deserializeMention(jsonString)
+    val jsonString = jsonSerializer.asJsonString(m)
+    val deserialized = jsonSerializer.deserializeMention(jsonString)
     mentionsShouldBeEqual(m, deserialized) should be(true)
 
-    val jsonPretty = JsonSerializer.asJsonPretty(m)
-    val deserializedPretty = JsonSerializer.deserializeMention(jsonPretty)
+    val jsonPretty = jsonSerializer.asJsonPretty(m)
+    val deserializedPretty = jsonSerializer.deserializeMention(jsonPretty)
     mentionsShouldBeEqual(m, deserializedPretty) should be(true)
   }
 
   it should "properly serialize and deserialized using json lines" in {
     val m1 = getSingleMentionFromRule(mentions, "Or")
     val m2 = getSingleMentionFromRule(mentions, "Named")
-    val jsonLines = JsonSerializer.asJsonLines(Seq(m1, m2))
-    val deserialized = JsonSerializer.deserializeJsonLines(jsonLines)
+    val jsonLines = jsonSerializer.asJsonLines(Seq(m1, m2))
+    val deserialized = jsonSerializer.deserializeJsonLines(jsonLines)
     deserialized should have length (2)
     mentionsShouldBeEqual(m1, deserialized(0)) should be(true)
     mentionsShouldBeEqual(m2, deserialized(1)) should be(true)
+  }
+
+  "JsonSerializer with verbose=display" should "include the display field and content" in {
+    val nonevent = getSingleMentionFromRule(mentions, "MultipleWords")
+    val json = displaySerializer.asJsonValue(nonevent)
+    val detail = json("detail")
+    val raw = detail("raw").arr.map(_.str)
+    raw should contain inOrderOnly ("Rainbows", "shine", "bright")
+
+    a [java.util.NoSuchElementException] should be thrownBy json("lemma")
+  }
+
+  "JsonSerializer with verbose=all" should "include the all stored fields and content" in {
+    val nonevent = getSingleMentionFromRule(mentions, "MultipleWords")
+    val json = allSerializer.asJsonValue(nonevent)
+    val detail = json("detail")
+
+    detail("raw").arr.map(_.str) should contain inOrderOnly ("Rainbows", "shine", "bright")
+    detail("lemma").arr.map(_.str) should contain inOrderOnly ("rainbow", "shine", "bright")
+    detail("tag").arr.map(_.str) should contain inOrderOnly ("NNS", "VBP", "JJ")
+
+    a [java.util.NoSuchElementException] should be thrownBy json("watermelon")
   }
 
 }

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -2,6 +2,7 @@ package ai.lum.odinson.serialization
 
 import java.util
 
+import ai.lum.odinson.serialization.JsonSerializer.VerboseLevels
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import com.typesafe.config.ConfigValueFactory
@@ -26,13 +27,13 @@ class TestJsonSerialization extends OdinsonTest {
   val mentions = engine.extractNoState(extractors).toArray
 
   val jsonSerializer =
-    new JsonSerializer(verbose = JsonSerializer.NONE, indent = 4, engine = Some(engine))
+    new JsonSerializer(verbose = VerboseLevels.Minimal, indent = 4, engine = Some(engine))
 
   val displaySerializer =
-    new JsonSerializer(verbose = JsonSerializer.DISPLAY, indent = 4, engine = Some(verboseEngine))
+    new JsonSerializer(verbose = VerboseLevels.Display, indent = 4, engine = Some(verboseEngine))
 
   val allSerializer =
-    new JsonSerializer(verbose = JsonSerializer.ALL, indent = 4, engine = Some(verboseEngine))
+    new JsonSerializer(verbose = VerboseLevels.All, indent = 4, engine = Some(verboseEngine))
 
   "JsonSerializer" should "handle NGramMentions" in {
     val m = getSingleMentionFromRule(mentions, "NGram")

--- a/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
+++ b/core/src/test/scala/ai/lum/odinson/serialization/TestJsonSerialization.scala
@@ -243,16 +243,18 @@ class TestJsonSerialization extends OdinsonTest {
     val nonevent = getSingleMentionFromRule(mentions, "MultipleWords")
     val json = displaySerializer.asJsonValue(nonevent)
     val detail = json("detail")
-    val raw = detail("raw").arr.map(_.str)
+    val raw = detail("mention")("raw").arr.map(_.str)
     raw should contain inOrderOnly ("Rainbows", "shine", "bright")
-
+    val docRaw = detail("document")("raw").arr.map(_.str)
+    docRaw.mkString(" ") shouldBe "Rainbows shine bright bright bright ."
+    
     a[java.util.NoSuchElementException] should be thrownBy json("lemma")
   }
 
   "JsonSerializer with verbose=all" should "include the all stored fields and content" in {
     val nonevent = getSingleMentionFromRule(mentions, "MultipleWords")
     val json = allSerializer.asJsonValue(nonevent)
-    val detail = json("detail")
+    val detail = json("detail")("mention")
 
     detail("raw").arr.map(_.str) should contain inOrderOnly ("Rainbows", "shine", "bright")
     detail("lemma").arr.map(_.str) should contain inOrderOnly ("rainbow", "shine", "bright")

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -22,8 +22,8 @@ odinson.indexDir = ${odinson.dataDir}/index
 odinson.extra {
     # processor to use for AnnotateText
     # choices: FastNLPProcessor, CluProcessor
-    #processorType    = "CluProcessor"
-    processorType     = "FastNLPProcessor"
+    processorType    = "CluProcessor"
+    #processorType     = "FastNLPProcessor"
     rulesFile = /example/rules.yml
     outputFile = ../example_extractions.jsonl
 }

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -22,8 +22,8 @@ odinson.indexDir = ${odinson.dataDir}/index
 odinson.extra {
     # processor to use for AnnotateText
     # choices: FastNLPProcessor, CluProcessor
-    processorType    = "CluProcessor"
-    #processorType     = "FastNLPProcessor"
+    #processorType    = "CluProcessor"
+    processorType     = "FastNLPProcessor"
     rulesFile = /example/rules.yml
     outputFile = ../example_extractions.jsonl
 }

--- a/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
@@ -9,6 +9,7 @@ import ai.lum.odinson.serialization.JsonSerializer
 import ai.lum.odinson.utils.DisplayUtils.displayMention
 import ai.lum.odinson.utils.SituatedStream
 import ai.lum.odinson.ExtractorEngine
+import ai.lum.odinson.serialization.JsonSerializer.VerboseLevels._
 import com.typesafe.scalalogging.LazyLogging
 import upickle.default._
 
@@ -53,8 +54,10 @@ object Example extends App with LazyLogging {
   mentions.foreach(displayMention(_, extractorEngine))
 
   // Export Mentions (here as json lines)
-  val jsonSerializer =
-    new JsonSerializer(verbose = JsonSerializer.DISPLAY, engine = Some(extractorEngine))
+  val jsonSerializer = {
+    // can choose several levels of verbosity: Minimal, Display, and All
+    new JsonSerializer(verbose = Display, engine = Some(extractorEngine))
+  }
 
   val serialized = jsonSerializer.asJsonLines(mentions)
   outputFile.writeString(serialized.mkString("\n"))

--- a/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Example.scala
@@ -53,7 +53,10 @@ object Example extends App with LazyLogging {
   mentions.foreach(displayMention(_, extractorEngine))
 
   // Export Mentions (here as json lines)
-  val serialized = JsonSerializer.asJsonLines(mentions)
+  val jsonSerializer =
+    new JsonSerializer(verbose = JsonSerializer.DISPLAY, engine = Some(extractorEngine))
+
+  val serialized = jsonSerializer.asJsonLines(mentions)
   outputFile.writeString(serialized.mkString("\n"))
 
 }


### PR DESCRIPTION
Added ability to serialize verbose json. options include: "none" (i.e., what we currently have), "display" (the displayField only), and "all" (all stored fields).
Verbose info is included in the json for **Mentions**, in the key "detail"

This change was implemented as a change from JsonSerializer being an object to it being a class, and the level of verbosity and the extractorengine (or None) that you want to use to get the detail is specified when the instance is created.

Also modifed the storedField behavior slightly, to require the displayField to be listed in the storedFields in the config, with an explicit check.

Tests added and modified accordingly.