### PR TITLE
draft of parent query documentation

### DIFF
--- a/docs/parent_queries.md
+++ b/docs/parent_queries.md
@@ -1,0 +1,40 @@
+---  
+title: Parent Queries
+parent: Queries
+has_children: false
+nav_order: 5
+---  
+
+# Parent queries
+
+Parent queries can be applied to document metadata provided as a json of token fields, e.g.:
+
+```
+"metadata": [
+  {
+    "$type": "ai.lum.odinson.TokensField",
+    "name": "show",
+    "tokens": ["Twin", "Peaks"]
+  },
+  {
+    "$type": "ai.lum.odinson.TokensField",
+    "name": "actor",
+    "tokens": ["Kyle", "MacLachlan"]
+  },
+  {
+    "$type": "ai.lum.odinson.TokensField",
+    "name": "character",
+    "tokens": ["Special", "Agent", "Dale", "Cooper"]
+  }
+]
+```
+
+Parent queries use [**Lucene query syntax**](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to query metadata fields. For instance, the parent query below will limit the document collection to only the documents related to the show Twin Peaks based on the example metadata above:
+
+    show: "Twin Peaks"
+
+The following parent query will limit the documents based on both the show and the actor:
+
+    character: "Special Agent Dale Cooper" AND show: "Fire Walk With Me"
+
+See the [testing suite](https://github.com/lum-ai/odinson/tree/master/core/src/test/scala/ai/lum/odinson/foundations/TestOdinsonParentQuery.scala) for more query examples. Parent queries are also available in the [REST API](https://github.com/clu-ling/odinson-example).

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,7 +1,7 @@
 ---  
 title: Queries
 has_children: true  
-nav_order: 5
+nav_order: 6
 ---  
 
 # Odinson queries
@@ -10,7 +10,9 @@ Odinson supports two main types of query patterns, **basic** queries and **event
 
 A [**basic query**](http://gh.lum.ai/odinson/basic_queries.html) minimally contains a token pattern (one or more token constraints), but optionally can also include graph traversals and additional token patterns.  Example:
 
-    girl >nmod_from Ipanema 
-    
+    girl >nmod_from Ipanema
+
 
 An [**event query**](event_queries.html) requires a `trigger`, a token pattern that indicates a possible match, and can have arguments, i.e., patterns _anchored on_ the trigger.  A simple example of this would be having a certain verb as a trigger (e.g., "cause"), and looking for the subject and object of the verb to serve as the agent and the theme of the event.
+
+In addition to the two types of queries above, aimed at matching patterns within the body of a document, Odinson supports [**parent queries**](parent_queries.html), which filter the document collection based on information in the document metadata before an odinson query executes. Parent queries use [**Lucene query syntax**](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html).


### PR DESCRIPTION
- added information about parent queries to documentation

Note: the link to the test suite is what I expect it to be in master when it's merged. 