### PR TITLE
Binary

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -116,10 +116,6 @@ odinson {
 
     maxNumberOfTokensPerSentence = 100
 
-    // SortedDocValuesField can store values of at most 32766 bytes long.
-    // See https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/document/SortedDocValuesField.html
-    sortedDocValuesFieldMaxSize = 32766
-
     // When indexing make sure to add the documents in the order of the external document id, so that the
     // results returned by queries will be ordered by external document id
     // WARNING: turning this on will slow the indexing process as documents will be parsed twice

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -6,21 +6,21 @@ import java.util.Collection
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConverters._
 import org.apache.lucene.util.BytesRef
-import org.apache.lucene.{document => lucenedoc}
+import org.apache.lucene.{ document => lucenedoc }
 import org.apache.lucene.document.Field.Store
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
-import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
+import org.apache.lucene.index.{ IndexWriter, IndexWriterConfig }
 import org.apache.lucene.index.IndexWriterConfig.OpenMode
-import org.apache.lucene.store.{Directory, FSDirectory, IOContext, RAMDirectory}
+import org.apache.lucene.store.{ Directory, FSDirectory, IOContext, RAMDirectory }
 import com.typesafe.scalalogging.LazyLogging
-import com.typesafe.config.{Config, ConfigValueFactory}
+import com.typesafe.config.{ Config, ConfigValueFactory }
 import ai.lum.common.ConfigFactory
 import ai.lum.common.ConfigUtils._
 import ai.lum.common.StringUtils._
 import ai.lum.common.DisplayUtils._
 import ai.lum.common.TryWithResources.using
 import ai.lum.odinson.lucene.analysis._
-import ai.lum.odinson.digraph.{DirectedGraph, Vocabulary}
+import ai.lum.odinson.digraph.{ DirectedGraph, Vocabulary }
 import ai.lum.odinson.serialization.UnsafeSerializer
 import ai.lum.odinson.utils.IndexSettings
 import ai.lum.odinson.utils.exceptions.OdinsonException

--- a/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
+++ b/core/src/main/scala/ai/lum/odinson/OdinsonIndexWriter.scala
@@ -37,7 +37,6 @@ class OdinsonIndexWriter(
   val addToNormalizedField: Set[String],
   val incomingTokenField: String,
   val outgoingTokenField: String,
-  val sortedDocValuesFieldMaxSize: Int,
   val maxNumberOfTokensPerSentence: Int,
   val invalidCharacterReplacement: String,
   val displayField: String
@@ -259,7 +258,6 @@ object OdinsonIndexWriter {
     val addToNormalizedField = config[List[String]]("odinson.index.addToNormalizedField")
     val incomingTokenField = config[String]("odinson.index.incomingTokenField")
     val outgoingTokenField = config[String]("odinson.index.outgoingTokenField")
-    val sortedDocValuesFieldMaxSize = config[Int]("odinson.index.sortedDocValuesFieldMaxSize")
     val maxNumberOfTokensPerSentence = config[Int]("odinson.index.maxNumberOfTokensPerSentence")
     val invalidCharacterReplacement = config[String]("odinson.index.invalidCharacterReplacement")
     val storedFields = config[List[String]]("odinson.index.storedFields")
@@ -291,7 +289,6 @@ object OdinsonIndexWriter {
       addToNormalizedField.toSet,
       incomingTokenField,
       outgoingTokenField,
-      sortedDocValuesFieldMaxSize,
       maxNumberOfTokensPerSentence,
       invalidCharacterReplacement,
       displayField

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/GraphTraversalQuery.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/GraphTraversalQuery.scala
@@ -88,7 +88,7 @@ class GraphTraversalQuery(
       val srcSpans = srcWeight.getSpans(context, requiredPostings)
       val traversalSpans = fullTraversal.getSpans(context, requiredPostings)
       if (srcSpans == null || traversalSpans == null) return null
-      val graphPerDoc = reader.getSortedDocValues(dependenciesField)
+      val graphPerDoc = reader.getBinaryDocValues(dependenciesField)
       val numWordsPerDoc = reader.getNumericDocValues(sentenceLengthField)
       val subSpans = srcSpans :: traversalSpans.subSpans
       new GraphTraversalSpans(
@@ -108,7 +108,7 @@ class GraphTraversalSpans(
   val subSpans: Array[OdinsonSpans],
   val srcSpans: OdinsonSpans,
   val fullTraversal: FullTraversalSpans,
-  val graphPerDoc: SortedDocValues,
+  val graphPerDoc: BinaryDocValues,
   val numWordsPerDoc: NumericDocValues
 ) extends ConjunctionSpans {
 

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonEventQuery.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonEventQuery.scala
@@ -197,7 +197,7 @@ class OdinsonEventQuery(
       // subSpans is required by ConjunctionSpans
       val subSpans = triggerSpans :: requiredSpans.flatMap(_.subSpans)
       // get graphs
-      val graphPerDoc = context.reader.getSortedDocValues(dependenciesField)
+      val graphPerDoc = context.reader.getBinaryDocValues(dependenciesField)
       // get token counts
       val numWordsPerDoc = context.reader.getNumericDocValues(sentenceLengthField)
       // return event spans
@@ -220,7 +220,7 @@ class OdinsonEventSpans(
   val triggerSpans: OdinsonSpans,
   val requiredSpans: List[ArgumentSpans],
   val optionalSpans: List[ArgumentSpans],
-  val graphPerDoc: SortedDocValues,
+  val graphPerDoc: BinaryDocValues,
   val numWordsPerDoc: NumericDocValues
 ) extends ConjunctionSpans {
 

--- a/core/src/main/scala/ai/lum/odinson/utils/TestUtils/OdinsonTest.scala
+++ b/core/src/main/scala/ai/lum/odinson/utils/TestUtils/OdinsonTest.scala
@@ -58,7 +58,7 @@ class OdinsonTest extends FlatSpec with Matchers {
     * @param value config value to replace the default value or serve as value to new key
     * @return
     */
-  def extractorEngineWithConfigValue(doc: Document, key: String, value: String): ExtractorEngine = {
+  def extractorEngineWithConfigValue(doc: Document, key: String, value: Any): ExtractorEngine = {
     val newConfig = defaultConfig.withValue(key, ConfigValueFactory.fromAnyRef(value))
     mkExtractorEngine(newConfig, doc)
   }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -3,15 +3,11 @@ package ai.lum.odinson.foundations
 // test imports
 import java.nio.file.Files
 
-import ai.lum.odinson.lucene.search.OdinsonIndexSearcher
 import ai.lum.odinson.utils.IndexSettings
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import com.typesafe.config.{Config, ConfigValueFactory}
-import org.apache.lucene.document.{BinaryDocValuesField, Document}
-import org.apache.lucene.index.DirectoryReader
 import org.apache.lucene.store.FSDirectory
-import org.apache.lucene.util.BytesRef
 
 import scala.collection.JavaConverters.asJavaIterableConverter
 // lum imports
@@ -150,7 +146,7 @@ class TestOdinsonIndexWriter extends OdinsonTest {
     an[OdinsonException] shouldBe thrownBy { OdinsonIndexWriter.fromConfig(customConfig) }
   }
 
-  it should "store and retrieve large graphs" in {
+//  it should "store and retrieve large graphs" in {
     // sortedDocValuesFieldMaxSize = 32766
 
 //    val large = Array.fill[Byte](40000)(217.toByte)
@@ -166,5 +162,5 @@ class TestOdinsonIndexWriter extends OdinsonTest {
 //    val computeTotalHits = true
 //    val indexSearcher = new OdinsonIndexSearcher(indexReader, computeTotalHits)
 
-  }
+//  }
 }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -132,7 +132,7 @@ class TestOdinsonIndexWriter extends OdinsonTest {
     ee.getTokensForSpan(0, "tag", 0, 1) should contain only "NNS"
     // though `entity` is a field in the Document, it wasn't stored, so the extractor engine shouldn't
     // be able to retrieve the content
-    an[Odin4sonException] should be thrownBy ee.getTokensForSpan(0, "entity", 0, 1)
+    an[OdinsonException] should be thrownBy ee.getTokensForSpan(0, "entity", 0, 1)
 
   }
 

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -3,19 +3,23 @@ package ai.lum.odinson.foundations
 // test imports
 import java.nio.file.Files
 
+import ai.lum.odinson.lucene.search.OdinsonIndexSearcher
 import ai.lum.odinson.utils.IndexSettings
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
-import com.typesafe.config.{ Config, ConfigValueFactory }
+import com.typesafe.config.{Config, ConfigValueFactory}
+import org.apache.lucene.document.{BinaryDocValuesField, Document}
+import org.apache.lucene.index.DirectoryReader
 import org.apache.lucene.store.FSDirectory
+import org.apache.lucene.util.BytesRef
 
 import scala.collection.JavaConverters.asJavaIterableConverter
 // lum imports
-import ai.lum.odinson.{ OdinsonIndexWriter, DateField, StringField }
-import ai.lum.common.ConfigFactory
+import ai.lum.odinson.{DateField, OdinsonIndexWriter, StringField}
 // file imports
-import scala.reflect.io.Directory
 import java.io.File
+
+import scala.reflect.io.Directory
 
 class TestOdinsonIndexWriter extends OdinsonTest {
   type Fixture = OdinsonIndexWriter
@@ -144,5 +148,23 @@ class TestOdinsonIndexWriter extends OdinsonTest {
     }
 
     an[OdinsonException] shouldBe thrownBy { OdinsonIndexWriter.fromConfig(customConfig) }
+  }
+
+  it should "store and retrieve large graphs" in {
+    // sortedDocValuesFieldMaxSize = 32766
+
+//    val large = Array.fill[Byte](40000)(217.toByte)
+//    val indexWriter = getOdinsonIndexWriter
+//    val graph = new BinaryDocValuesField("testfield", new BytesRef(large))
+//    val doc = new Document
+//    doc.add(graph)
+//    indexWriter.addDocuments(Seq(doc))
+//    indexWriter.commit()
+//    indexWriter.close()
+//
+//    val indexReader = DirectoryReader.open(FSDirectory.open(indexDir.toPath))
+//    val computeTotalHits = true
+//    val indexSearcher = new OdinsonIndexSearcher(indexReader, computeTotalHits)
+
   }
 }

--- a/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
+++ b/core/src/test/scala/ai/lum/odinson/foundations/TestIndexWriter.scala
@@ -6,12 +6,12 @@ import java.nio.file.Files
 import ai.lum.odinson.utils.IndexSettings
 import ai.lum.odinson.utils.TestUtils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
-import com.typesafe.config.{Config, ConfigValueFactory}
+import com.typesafe.config.{ Config, ConfigValueFactory }
 import org.apache.lucene.store.FSDirectory
 
 import scala.collection.JavaConverters.asJavaIterableConverter
 // lum imports
-import ai.lum.odinson.{DateField, OdinsonIndexWriter, StringField}
+import ai.lum.odinson.{ DateField, OdinsonIndexWriter, StringField }
 // file imports
 import java.io.File
 
@@ -147,7 +147,7 @@ class TestOdinsonIndexWriter extends OdinsonTest {
   }
 
 //  it should "store and retrieve large graphs" in {
-    // sortedDocValuesFieldMaxSize = 32766
+  // sortedDocValuesFieldMaxSize = 32766
 
 //    val large = Array.fill[Byte](40000)(217.toByte)
 //    val indexWriter = getOdinsonIndexWriter

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -66,10 +66,6 @@ odinson.index {
 
     maxNumberOfTokensPerSentence = 100
 
-    // SortedDocValuesField can store values of at most 32766 bytes long.
-    // See https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/document/SortedDocValuesField.html
-    sortedDocValuesFieldMaxSize = 32766
-
     // When indexing make sure to add the documents in the order of the external document id, so that the
     // results returned by queries will be ordered by external document id
     // WARNING: turning this on will slow the indexing process as documents will be parsed twice


### PR DESCRIPTION
Per request, switch to BinaryDocumentFields for the dependency graphs, allows for larger graphs.


@marcovzla a test is missing