### PR TITLE
Improve efficency of the term-freq endpoint

### DIFF
--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -85,11 +85,6 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
 
   class FrequencyTable(minIdx: Int, maxIdx: Int, reverse: Boolean) {
 
-//    class FrequencyRow[T](content: (T, Long))
-//
-//    case class SingleTermFrequencyRow(content: (String, Long)) extends FrequencyRow[String](content=content)
-//    case class DoubleTermFrequencyRow(content: ((String, String), Long)) extends FrequencyRow[(String, String)](content=content)
-
     private var freqs: List[(String, Long)] = Nil
 
     private def greaterThanOrEqualTo(reverse: Boolean)(first: Long, second: Long) =
@@ -269,8 +264,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
               Json.obj("term" -> term1, "group" -> term2, "frequency" -> freq)
           }
         }
-
-        Json.arr(jsonObjs).format(pretty)
+        Json.toJson(jsonObjs).format(pretty)
       } else {
         // the requested field isn't in this index
         Json.obj().format(pretty)

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -185,7 +185,7 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
                   val term = termsEnum.term.utf8ToString
                   termFreqs.enqueue((term, termsEnum.totalTermFreq))
                   // if we exceed the size we need, just throw the oldest away
-                  if(termFreqs.size > maxIdx) termFreqs.dequeue()
+                  if (termFreqs.size > maxIdx) termFreqs.dequeue()
                 }
                 termFreqs
                   .toIndexedSeq
@@ -281,19 +281,9 @@ class OdinsonController @Inject() (config: Config = ConfigFactory.load(), cc: Co
   /** Convenience method to determine if a string matches a given regular expression.
     * @param s The String to be searched.
     * @param regex The regular expression against which `s` should be compared.
-    * @return True if there's at least one match.
+    * @return True if the whole expression matches.
     */
-  private def isMatch(s: String, regex: Option[String]): Boolean = {
-    if (regex.isEmpty) true
-    // .* is necessary
-    else {
-      val pattern = regex.get.r
-      pattern.findFirstMatchIn(s) match {
-        case Some(_) => true
-        case _       => false
-      }
-    }
-  }
+  private def isMatch(s: String, regex: Option[String]): Boolean = s.matches(regex.getOrElse(".*"))
 
   case class RuleFreqRequest(
     grammar: String,

--- a/backend/test/controllers/OdinsonControllerSpec.scala
+++ b/backend/test/controllers/OdinsonControllerSpec.scala
@@ -1,11 +1,11 @@
 package controllers
 
-import java.io.{File, IOException}
+import java.io.{ File, IOException }
 import java.nio.file.Files
 
 import ai.lum.odinson.extra.IndexDocuments
 import ai.lum.odinson.utils.exceptions.OdinsonException
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.scalatestplus.play.guice._
 import play.api.test.Helpers._
 import org.apache.commons.io.FileUtils
@@ -239,25 +239,26 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
       // check that the response is valid in form
       val rowsResult = json.validate(readSingletonRows)
-      rowsResult.isSuccess must be (true)
+      rowsResult.isSuccess must be(true)
 
       // check that 10 results are returned by default
       val rows: Seq[SingletonRow] = rowsResult match {
         case r: JsResult[SingletonRows] => r.get
-        case _ => Nil
+        case _                          => Nil
       }
 
       rows must have length (10)
 
       // check for ordering (greatest to least)
       val freqs = rows.map(_.frequency)
-      freqs.zip(freqs.tail).foreach{ case(freq1, freq2) =>
-          freq1 must be >= freq2
+      freqs.zip(freqs.tail).foreach { case (freq1, freq2) =>
+        freq1 must be >= freq2
       }
     }
 
     "respond with grouped token-based frequencies using the /term-freq endpoint" in {
-      val response = route(app, FakeRequest(GET, "/api/term-freq?field=tag&group=raw&min=0&max=4")).get
+      val response =
+        route(app, FakeRequest(GET, "/api/term-freq?field=tag&group=raw&min=0&max=4")).get
 
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
@@ -270,27 +271,30 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
       // check that the response is of a valid form
       val rowsResult = json.validate(readGroupedRows)
-      rowsResult.isSuccess must be (true)
+      rowsResult.isSuccess must be(true)
 
       // check that we have the right number of results
       val rows: Seq[GroupedRow] = rowsResult match {
         case r: JsResult[GroupedRows] => r.get
-        case _ => Nil
+        case _                        => Nil
       }
       // important to save ordering
       val termOrder = rows.map(_.term).distinct.zipWithIndex.toMap
-      val rowsForTerm = rows.groupBy(_.term).toSeq.sortBy{ case (term, frequencies) => termOrder(term) }
+      val rowsForTerm = rows.groupBy(_.term).toSeq.sortBy { case (term, frequencies) =>
+        termOrder(term)
+      }
       rowsForTerm must have length (5)
 
       // check for ordering among `term`s (greatest to least)
-      val termFreqs = rowsForTerm.map{ case (term, rows) => rows.map(_.frequency).sum }
-      termFreqs.zip(termFreqs.tail).foreach{ case(freq1, freq2) =>
+      val termFreqs = rowsForTerm.map { case (term, rows) => rows.map(_.frequency).sum }
+      termFreqs.zip(termFreqs.tail).foreach { case (freq1, freq2) =>
         freq1 must be >= freq2
       }
     }
 
     "respond to order and reverse variables in /term-freq endpoint" in {
-      val response = route(app, FakeRequest(GET, "/api/term-freq?field=word&order=alpha&reverse=true")).get
+      val response =
+        route(app, FakeRequest(GET, "/api/term-freq?field=word&order=alpha&reverse=true")).get
 
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
@@ -302,17 +306,17 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
       // check that the response is valid in form
       val rowsResult = json.validate(readSingletonRows)
-      rowsResult.isSuccess must be (true)
+      rowsResult.isSuccess must be(true)
 
       // check that 10 results are returned by default
       val rows: Seq[SingletonRow] = rowsResult match {
         case r: JsResult[SingletonRows] => r.get
-        case _ => Nil
+        case _                          => Nil
       }
 
       // check for ordering (reverse Unicode sort)
       val terms = rows.map(_.term)
-      terms.zip(terms.tail).foreach{ case(term1, term2) =>
+      terms.zip(terms.tail).foreach { case (term1, term2) =>
         // no overlap because terms must be distinct
         term1 must be > term2
       }
@@ -332,21 +336,21 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
       // check that the response is valid in form
       val rowsResult = json.validate(readSingletonRows)
-      rowsResult.isSuccess must be (true)
+      rowsResult.isSuccess must be(true)
 
       val rows: Seq[SingletonRow] = rowsResult match {
         case r: JsResult[SingletonRows] => r.get
-        case _ => Nil
+        case _                          => Nil
       }
 
       // regex is `^t` and is meant to be unanchored (on the right) and case sensitive
       // check that all terms begin with lowercase t, and that there's at least one term that isn't
       // just `t`
       val terms = rows.map(_.term)
-      terms.foreach{ term =>
+      terms.foreach { term =>
         term.startsWith("th") mustBe (true)
       }
-      terms.exists{ term =>
+      terms.exists { term =>
         term.length > 1
       } mustBe (true)
     }


### PR DESCRIPTION
The previous implementation of term-freq (the API endpoint for returning graphable JSON tables of term frequency in a dataset) was inefficient to the point of timing out rather than returning for even basic queries. The following corrections improve this performance:

1. Use Lucene's native `RegExp` and `Automaton` classes to filter terms rather than checking each term with Scala regex.
2. Create a `FrequencyTable` class for iteratively tracking the highest-ranked (by lowest or highest frequency order, as requested) terms. Use a `Queue`-like `List` structure, inserting new terms that are higher-ranked than the current boundary and pushing out terms beyond the `max` requested index. This means that sorting is done as terms are examined, and there is no additional need to sort a large `List` of terms after retrieving frequencies.
3. When the API call requests alphanumeric ordering, take terms off of the `TermEnum` in sequence until we have `max +1` of them. This is possible because `TermEnum` uses alphanumeric (Unicode sort) order. Unfortunately, this means that if the API call also requests reverse order (i.e. last alphanumeric first), the system needs to iterate through all the terms, but as it only needs to save the last `max + 1` items, this action is still speedy.

The relevant issue is https://github.com/lum-ai/odinson-ide/issues/53