### PR TITLE
AnnotateText: replicate the directory structure under textDir under d…

### DIFF
--- a/extra/src/main/scala/ai/lum/odinson/extra/AnnotateText.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/AnnotateText.scala
@@ -70,7 +70,8 @@ object AnnotateText extends App with LazyLogging {
     val inputFileInDocsDir = docsDir.toPath.resolve(relFile)
     val docFile = inputFileInDocsDir.getParent
       .resolve(inputFileInDocsDir.getFileName.toFile.getBaseName() + ".json.gz").toFile
-    Ensuring(docFile.toPath.getParent.toFile.mkdirs)
+    docFile.toPath.getParent.toFile.mkdirs
+    Ensuring(docFile.toPath.getParent.toFile.exists())
 
     if (docFile.exists) {
       logger.warn(s"${docFile.getCanonicalPath} already exists")

--- a/extra/src/test/resources/text/text-subdir/test-text-subdir-text.txt
+++ b/extra/src/test/resources/text/text-subdir/test-text-subdir-text.txt
@@ -1,0 +1,1 @@
+The CCP has children too!

--- a/extra/src/test/scala/ai/lum/odinson/extra/TestAnnotateDocuments.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/TestAnnotateDocuments.scala
@@ -1,11 +1,10 @@
 package ai.lum.odinson.extra
 
-import java.nio.file.Files
-
+import java.nio.file.{ Files, Paths }
 import ai.lum.odinson.Document
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import org.scalatest._
-import java.io.{ File, IOException }
+import java.io.IOException
 import org.apache.commons.io.FileUtils
 
 import scala.reflect.io.Directory
@@ -13,60 +12,74 @@ import scala.reflect.io.Directory
 class TestAnnotateDocuments extends FlatSpec with Matchers {
 
   // get the resources directory and the text directory where the text to annotate is stored
-  val resourcesFolder = getClass.getResource("/").getFile
-  val srcTextDir = new File(resourcesFolder, "text")
+  private val resourcesFolder = getClass.getResource("/").getFile
+  private val srcTextDir = Paths.get(resourcesFolder, "text")
 
   // create the temporary test directory
-  val tmpFolder = Files.createTempDirectory("odinson-test").toFile().getAbsolutePath
+  private val tmpFolder = Files.createTempDirectory("odinson-test").toFile.getAbsolutePath
 
   // create directories and files that will be used during the test
-  val dataDir = tmpFolder
-  val textDir = new File(dataDir, "text")
-  val docsDir = new File(tmpFolder, "docs")
-  val serializedTestFile = new File(docsDir, "test-text.json.gz")
+  private val dataDir = tmpFolder
+  private val textDir = Paths.get(dataDir, "text")
+  private val docsDir = Paths.get(tmpFolder, "docs")
+  private val serializedTestFile = docsDir.resolve("test-text.json.gz")
+  private val serializedTestChildDir = docsDir.resolve("text-subdir")
+
+  private val serializedTestChildFile =
+    serializedTestChildDir.resolve("test-text-subdir-text.json.gz")
 
   // copy the text to annotate into the temporary test directory
   try {
-    FileUtils.copyDirectory(srcTextDir, textDir)
+    FileUtils.copyDirectory(srcTextDir.toFile, textDir.toFile)
   } catch {
     case e: IOException =>
-      throw new OdinsonException(s"Can't copy text directory ${srcTextDir}")
+      throw new OdinsonException(s"Can't copy text directory $srcTextDir")
   }
 
-  def deleteDocs = {
-    val dir = new Directory(docsDir)
+  private def deleteDocs() = {
+    val dir = new Directory(docsDir.toFile)
     dir.deleteRecursively()
   }
 
-  "AnnotateDocuments" should "get the correct annotated, deserializeable Document file when processing with FastNLPProcessor" in {
+  "AnnotateDocuments" should "get the correct annotated, deserializable Document file when processing with FastNLPProcessor" in {
 
-    //delete docs if already exists
-    deleteDocs
+    // delete docs if they already exist
+    deleteDocs()
 
     // run the annotation
     AnnotateText.main(Array(tmpFolder, "FastNLPProcessor"))
 
-    docsDir.listFiles() should contain(serializedTestFile)
+    Files.walk(docsDir).toArray should contain(serializedTestFile)
+    Files.walk(docsDir).toArray should contain(serializedTestChildDir)
+    Files.walk(docsDir).toArray should contain(serializedTestChildFile)
 
-    val deserialized = Document.fromJson(serializedTestFile)
+    val deserialized = Document.fromJson(serializedTestFile.toFile)
 
     deserialized.getClass.toString shouldEqual "class ai.lum.odinson.Document"
 
+    val deserializedChild = Document.fromJson(serializedTestFile.toFile)
+
+    deserializedChild.getClass.toString shouldEqual "class ai.lum.odinson.Document"
   }
 
-  "AnnotateDocuments" should "get the correct annotated, deserializeable Document file when processing with CluProcessor" in {
+  "AnnotateDocuments" should "get the correct annotated, deserializable Document file when processing with CluProcessor" in {
 
-    //delete docs if already exists
-    deleteDocs
+    // delete docs if they already exist
+    deleteDocs()
 
     // run the annotation
     AnnotateText.main(Array(tmpFolder, "CluProcessor"))
 
-    docsDir.listFiles() should contain(serializedTestFile)
+    Files.walk(docsDir).toArray should contain(serializedTestFile)
+    Files.walk(docsDir).toArray should contain(serializedTestChildDir)
+    Files.walk(docsDir).toArray should contain(serializedTestChildFile)
 
-    val deserialized = Document.fromJson(serializedTestFile)
+    val deserialized = Document.fromJson(serializedTestFile.toFile)
 
     deserialized.getClass.toString shouldEqual "class ai.lum.odinson.Document"
 
+    val deserializedChild = Document.fromJson(serializedTestFile.toFile)
+
+    deserializedChild.getClass.toString shouldEqual "class ai.lum.odinson.Document"
   }
 }


### PR DESCRIPTION
`AnnotateText`: replicate the directory structure under textDir under docsDir
- makes best practice of not having too many files in a single dir easier