### PR TITLE
changes and version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Enhanced term-freq endpoint to allow filtering as well as grouping by a second field.
 - Added ability to Mentions to populate their lexical content ([#274](https://github.com/lum-ai/odinson/pull/274))
 ### Changed
+- Dependencies now stored as BinaryDocValuesField (previously SortedDocValuesField) to allow for larger graphs ([#283](https://github.com/lum-ai/odinson/pull/283)).
 - Moved responsibility for getting lexical content from ExtractorEngine to DataGatherer ([#274](https://github.com/lum-ai/odinson/pull/274))
 
 ## [0.3.0] - 2021-02-18

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
We forgot to do this back on #283  👎 

The increase in the major version is bc indexes made prior are no longer compatible.