### PR TITLE
Make parent document's `fileName` a `storedField` by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added tests for metadata and parent API calls in backend.
 ### Changed
+- Parent document filenames are stored by default.
 
 ## [0.4.0] - 2021-06-07
 ### Added
@@ -14,12 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Enhanced term-freq endpoint to allow filtering as well as grouping by a second field.
 - Added ability to Mentions to populate their lexical content ([#274](https://github.com/lum-ai/odinson/pull/274))
 - Added tests for parent queries in core and backend.
-- Added tests for metadata and parent API calls in backend. 
 ### Changed
 - Dependencies now stored as BinaryDocValuesField (previously SortedDocValuesField) to allow for larger graphs ([#283](https://github.com/lum-ai/odinson/pull/283)).
 - Moved responsibility for getting lexical content from ExtractorEngine to DataGatherer ([#274](https://github.com/lum-ai/odinson/pull/274))
 - Metadata is now indexed as TokensFields instead of StringFields.
-- Parent document filenames are stored by default.
 
 ## [0.3.0] - 2021-02-18
 ### Added 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
-- Added tests for metadata and parent API calls in backend.
 - Added tags-vocabulary endpoint to API for index-specific part-of-speech tags.
+- Added tests for metadata and parent API calls in backend.
 ### Changed
 - Parent document filenames are stored by default.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,10 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Enhanced term-freq endpoint to allow filtering as well as grouping by a second field.
 - Added ability to Mentions to populate their lexical content ([#274](https://github.com/lum-ai/odinson/pull/274))
 - Added tests for parent queries in core and backend.
+- Added tests for metadata and parent API calls in backend. 
 ### Changed
 - Dependencies now stored as BinaryDocValuesField (previously SortedDocValuesField) to allow for larger graphs ([#283](https://github.com/lum-ai/odinson/pull/283)).
 - Moved responsibility for getting lexical content from ExtractorEngine to DataGatherer ([#274](https://github.com/lum-ai/odinson/pull/274))
 - Metadata is now indexed as TokensFields instead of StringFields.
+- Parent document filenames are stored by default.
 
 ## [0.3.0] - 2021-02-18
 ### Added 

--- a/backend/test/controllers/OdinsonControllerSpec.scala
+++ b/backend/test/controllers/OdinsonControllerSpec.scala
@@ -596,6 +596,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
       responseString must include("distinctDependencyRelations")
       responseString must include("tokenFields")
       responseString must include("docFields")
+      responseString must include("storedFields")
     }
 
     "respond with dependencies list using the /dependencies-vocabulary endpoint" in {

--- a/backend/test/controllers/OdinsonControllerSpec.scala
+++ b/backend/test/controllers/OdinsonControllerSpec.scala
@@ -284,6 +284,49 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerTest with Inject
 
     }
 
+    "retrieve metadata using the /metadata/by-sentence-id endpoint" in {
+      val response = route(app, FakeRequest(GET, "/api/metadata/by-sentence-id?sentenceId=2")).get
+
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+
+      Helpers.contentAsString(response) must include("ai.lum.odinson.TokensField")
+      Helpers.contentAsString(response) must include("Garland")
+    }
+
+    "retrieve metadata using the /metadata/by-document-id endpoint" in {
+      val response =
+        route(app, FakeRequest(GET, "/api/metadata/by-document-id?documentId=tp-pies")).get
+
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+
+      Helpers.contentAsString(response) must include("ai.lum.odinson.TokensField")
+      Helpers.contentAsString(response) must include("Cooper")
+    }
+
+    "retrieve the parent doc using the /parent/by-sentence-id endpoint" in {
+      val response = route(app, FakeRequest(GET, "/api/parent/by-sentence-id?sentenceId=2")).get
+
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+
+      Helpers.contentAsString(response) must include("Briggs") // metadata
+      Helpers.contentAsString(response) must include("subconscious") // this sentence
+      Helpers.contentAsString(response) must include("veranda") // other sentences in parent
+    }
+
+    "retrieve the parent doc using the /parent/by-document-id endpoint" in {
+      val response =
+        route(app, FakeRequest(GET, "/api/parent/by-document-id?documentId=tp-pies")).get
+
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+
+      Helpers.contentAsString(response) must include("MacLachlan") // metadata
+      Helpers.contentAsString(response) must include("pies") // sentence info
+    }
+
     "respond with token-based frequencies using the /term-freq endpoint" in {
       val response = route(app, FakeRequest(GET, "/api/term-freq?field=word")).get
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -77,7 +77,10 @@ odinson {
   index {
 
     # list of document/sentence fields to store in index, **must** include the displayField
-    storedFields = [${odinson.displayField}]
+    storedFields = [
+        ${odinson.displayField},
+        ${odinson.index.parentDocFieldFileName}
+    ]
 
     # the raw token
     rawTokenField = raw

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -76,7 +76,8 @@ odinson {
 
   index {
 
-    # list of document/sentence fields to store in index, **must** include the displayField
+    # list of document/sentence fields to store in index,
+    # **must** include the displayField and parentDocFieldFileName
     storedFields = [
         ${odinson.displayField},
         ${odinson.index.parentDocFieldFileName}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -76,8 +76,8 @@ odinson {
 
   index {
 
-    # list of document/sentence fields to store in index,
-    # **must** include the displayField and parentDocFieldFileName
+    # list of document/sentence fields to store in index, **must** include the displayField
+    # parentDocFieldFileName is required for multiple API endpoints
     storedFields = [
         ${odinson.displayField},
         ${odinson.index.parentDocFieldFileName}

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -17,6 +17,15 @@ object IndexDocuments extends App with LazyLogging {
 
   var config = ConfigFactory.load()
 
+  // Warn that the API requires parentDocFieldFileName
+  val storedFields = config.apply[List[String]]("odinson.index.storedFields")
+  val fileNameField = config.apply[String]("odinson.index.parentDocFieldFileName")
+  if (!storedFields.contains(fileNameField)) {
+    logger.warn(
+      "`odinson.index.storedFields` must contain `odinson.index.parentDocFieldFileName` to enable the Odinson API"
+    )
+  }
+
   if (args.length == 1) {
 
     val dirPath = args(0)


### PR DESCRIPTION
In the Odinson API, multiple endpoints rely on the parent file being available to return or consume. This is only possible if the `parentDocFieldFileName` is stored in the index. This fact was undiscovered because there were no tests for these endpoints. These changes add `parentDocFieldFileName` to the `storedFields`, add simple tests for the 4 endpoints in question, and edit the `storedFields` comment to encourage the use of `parentDocFieldFileName`.

Closes #303