### PR TITLE
Parent file location field is stored by default

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -76,8 +76,11 @@ odinson {
 
     # list of document/sentence fields to store in index, **must** include the displayField
     storedFields = [
-        ${odinson.displayField}
+        ${odinson.displayField},
+        ${odinson.index.parentDocFieldFileName}
     ]
+
+    parentDocFieldFileName = fileName
 
     # the raw token
     rawTokenField = raw


### PR DESCRIPTION
The REST API requires the parent filename field to be stored, so store it by default.