### PR TITLE
added parentDocFieldFileName to backend conf

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -1,5 +1,7 @@
-# Configuration for Play's AkkaHttpServer
+# Configurations for ensuring the backend can properly use the index
+odinson.index.parentDocFieldFileName = fileName
 
+# Configuration for Play's AkkaHttpServer
 play {
 
   http {


### PR DESCRIPTION
Added the needed config value.  Tricky to test because of the subproject dependencies.  Specifically, the _test_ module of `backend` has access to `extra`, and since this key was defined in the `extra` conf, the tests were passing though the primary backend code wasn't.  I did verify that this patch allows the `OdinsonController` access to the missing config key though.

closes #318 