### PR TITLE
Update docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ Odinson consists of the following subprojects:
 
 - **core**: the core odinson library
 - **extra**: these are a few apps that we need but don't really belong in `core`, due to things like licensing issues
-- **backend**: this is a REST API for odinson
     
-  
+A REST API is also available in [`odinson-rest`](https://github.com/lum-ai/odinson-rest)
+
 ## License  
 
 Odinson is Apache License Version 2.0. 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -45,7 +45,8 @@ Or, if customization is needed, you can use these steps in your own code:
 
 ```scala
 import ai.lum.common.FileUtils._
-import ai.lum.odinson.{Document, OdinsonIndexWriter}
+import ai.lum.odinson.Document
+import ai.lum.odinson.lucene.index.OdinsonIndexWriter
 
 // Initialize the index writer
 val writer = OdinsonIndexWriter.fromConfig()


### PR DESCRIPTION
- `OdinsonIndexWriter` was moved to `ai.lum.odinson.lucene.index.` in #363 