### PR TITLE
Paginate using Lucene Doc ID

### DIFF
--- a/core/src/main/scala/ai/lum/odinson/lucene/index/IncrementalOdinsonIndex.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/index/IncrementalOdinsonIndex.scala
@@ -265,13 +265,13 @@ class IncrementalOdinsonIndex(
   }
 
   override def search(
-    scoreDoc: OdinsonScoreDoc,
+    luceneDocId: Int,
     query: OdinsonQuery,
     cappedHits: Int,
     disableMatchSelector: Boolean
   ): OdinResults = {
     val manager =
-      new OdinsonCollectorManager(scoreDoc, cappedHits, computeTotalHits, disableMatchSelector)
+      new OdinsonCollectorManager(luceneDocId, cappedHits, computeTotalHits, disableMatchSelector)
     this.search(query, manager)
   }
 

--- a/core/src/main/scala/ai/lum/odinson/lucene/index/OdinsonCollectorManager.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/index/OdinsonCollectorManager.scala
@@ -8,7 +8,7 @@ import java.util.Collection
 import scala.collection.JavaConverters._
 
 class OdinsonCollectorManager(
-  after: OdinsonScoreDoc,
+  after: Int,
   cappedNumHits: Int,
   computeTotalHits: Boolean,
   disableMatchSelector: Boolean

--- a/core/src/main/scala/ai/lum/odinson/lucene/index/OdinsonIndex.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/index/OdinsonIndex.scala
@@ -116,7 +116,7 @@ trait OdinsonIndex {
   ): ResultType
 
   def search(
-    scoreDoc: OdinsonScoreDoc,
+    luceneDocId: Int,
     query: OdinsonQuery,
     cappedHits: Int,
     disableMatchSelector: Boolean

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonCollector.scala
@@ -23,20 +23,6 @@ class OdinsonCollector(
     this(numHits, -1, computeTotalHits, disableMatchSelector)
   }
 
-  def this(
-    numHits: Int,
-    afterDoc: OdinsonScoreDoc,
-    computeTotalHits: Boolean,
-    disableMatchSelector: Boolean
-  ) = {
-    this(
-      numHits,
-      if (afterDoc == null) -1 else afterDoc.doc,
-      computeTotalHits,
-      disableMatchSelector
-    )
-  }
-
   private var totalHits: Int = 0
   private var collectedHits: Int = 0
 

--- a/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonIndexSearcher.scala
+++ b/core/src/main/scala/ai/lum/odinson/lucene/search/OdinsonIndexSearcher.scala
@@ -34,15 +34,15 @@ class OdinsonIndexSearcher(
   }
 
   def odinSearch(query: OdinsonQuery, n: Int): OdinResults = {
-    odinSearch(null, query, n)
+    odinSearch(-1, query, n)
   }
 
-  def odinSearch(after: OdinsonScoreDoc, query: OdinsonQuery, numHits: Int): OdinResults = {
+  def odinSearch(after: Int, query: OdinsonQuery, numHits: Int): OdinResults = {
     odinSearch(after, query, numHits, false)
   }
 
   class StandardCollectorManager(
-    after: OdinsonScoreDoc,
+    after: Int,
     cappedNumHits: Int,
     disableMatchSelector: Boolean
   ) extends CollectorManager[OdinsonCollector, OdinResults] {
@@ -60,15 +60,15 @@ class OdinsonIndexSearcher(
   }
 
   def odinSearch(
-    after: OdinsonScoreDoc,
+    after: Int,
     query: OdinsonQuery,
     numHits: Int,
     disableMatchSelector: Boolean
   ): OdinResults = {
     val limit = math.max(1, readerContext.reader().maxDoc())
     require(
-      after == null || after.doc < limit,
-      s"after.doc exceeds the number of documents in the reader: after.doc=${after.doc} limit=${limit}"
+      after < limit,
+      s"after exceeds the number of documents in the reader: after=${after} limit=${limit}"
     )
     val cappedNumHits = math.min(numHits, limit)
     val manager = new StandardCollectorManager(after, cappedNumHits, disableMatchSelector)

--- a/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
+++ b/core/src/test/scala/ai/lum/odinson/events/TestEvents.scala
@@ -1,7 +1,7 @@
 package ai.lum.odinson.events
 
 import ai.lum.odinson.lucene.OdinResults
-import ai.lum.odinson.lucene.search.{ OdinsonQuery, OdinsonScoreDoc }
+import ai.lum.odinson.lucene.search.OdinsonQuery
 import ai.lum.odinson.test.utils.OdinsonTest
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import ai.lum.odinson.{ EventMatch, MentionsIterator }
@@ -197,7 +197,7 @@ class TestEvents extends OdinsonTest {
       labelOpt: Option[String] = None,
       nameOpt: Option[String] = None,
       n: Int,
-      after: OdinsonScoreDoc,
+      after: Int,
       disableMatchSelector: Boolean
     ): OdinResults = {
       val odinResults = ee.query(odinsonQuery, n, after, disableMatchSelector)
@@ -214,14 +214,14 @@ class TestEvents extends OdinsonTest {
       labelOpt = Some("NP"),
       nameOpt = None,
       1,
-      after = null,
+      after = -1,
       disableMatchSelector = false
     )
     results1.totalHits should equal(1)
     results1.scoreDocs.head.matches should have size 2
 
     // This query only needs to read from the state.
-    val results2 = ee.query(q2, 1, after = null, disableMatchSelector = false)
+    val results2 = ee.query(q2, 1, after = -1, disableMatchSelector = false)
     results2.totalHits should equal(1)
     results2.scoreDocs.head.matches should have size 1
 

--- a/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/Shell.scala
@@ -173,7 +173,7 @@ object Shell extends App {
 
   def getLastDocId(scoreDocs: Array[OdinsonScoreDoc]): Int = scoreDocs.lastOption match {
     case Some(sd) => sd.doc
-    case _ => -1
+    case _        => -1
   }
 
   /** searches for pattern and prints the first n matches */

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.0-RC1
+sbt.version=1.6.1


### PR DESCRIPTION
This PR simplifies the pagination process by using a Lucene doc ID, rather than an `OdinsonScoreDoc`.