### PR TITLE
Integrate BioNLPProcessor with Odinson

### DIFF
--- a/extra/build.sbt
+++ b/extra/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= {
     "ai.lum"     %% "nxmlreader"            % "0.1.2",
     "org.clulab" %% "processors-main"       % procVersion,
     "org.clulab" %% "processors-corenlp"    % procVersion,
+    "org.clulab" %% "reach-processors"      % "1.6.3-SNAPSHOT"
   )
 
 }

--- a/extra/src/main/resources/application.conf
+++ b/extra/src/main/resources/application.conf
@@ -23,8 +23,9 @@ odinson.indexDir = ${odinson.dataDir}/index
 odinson.extra {
     # processor to use for AnnotateText
     # choices: FastNLPProcessor, CluProcessor
-    processorType    = "CluProcessor"
+    #processorType    = "CluProcessor"
     #processorType     = "FastNLPProcessor"
+    processorType    = "BioNLPProcessor"
     rulesFile = /example/rules.yml
     outputFile = ../example_extractions.jsonl
 }

--- a/extra/src/main/scala/ai/lum/odinson/extra/AnnotateText.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/AnnotateText.scala
@@ -13,6 +13,7 @@ import ai.lum.odinson.Document
 import ai.lum.odinson.extra.utils.{ ExtraFileUtils, ProcessorsUtils }
 import ai.lum.odinson.extra.utils.ProcessorsUtils.getProcessor
 import org.clulab.utils.FileUtils
+import org.clulab.processors.bionlp.BioNLPProcessor
 
 object AnnotateText extends App with LazyLogging {
 
@@ -59,6 +60,10 @@ object AnnotateText extends App with LazyLogging {
   def annotateTextFile(f: File): Document = {
     val text = f.readString()
     val doc = processor.annotate(text)
+    processor match {
+      case p:BioNLPProcessor =>
+        p.recognizeRuleNamedEntities(doc)
+    }
     // use file base name as document id
     doc.id = Some(f.getBaseName())
     ProcessorsUtils.convertDocument(doc)

--- a/extra/src/main/scala/ai/lum/odinson/extra/utils/ProcessorsUtils.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/utils/ProcessorsUtils.scala
@@ -8,6 +8,7 @@ import ai.lum.odinson.{ Document => OdinsonDocument, Sentence => OdinsonSentence
 import org.clulab.dynet
 import org.clulab.processors.clu.CluProcessor
 import org.clulab.processors.fastnlp.FastNLPProcessor
+import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.processors.{
   Processor,
   Document => ProcessorsDocument,
@@ -41,6 +42,10 @@ object ProcessorsUtils {
       case "CluProcessor" => {
         dynet.Utils.initializeDyNet(autoBatch = false, mem = "1024,1024,1024,1024")
         new CluProcessor
+      }
+      case "BioNLPProcessor" => {
+        dynet.Utils.initializeDyNet(autoBatch = false, mem = "1024,1024,1024,1024")
+        new BioNLPProcessor
       }
     }
   }


### PR DESCRIPTION
This PR adds the BioNLPProcessor as one of the processor choices used for annotation. See https://github.com/clulab/reach/issues/802.

**WARNING**: review for changing dependencies (this only works if Reach is available as a dependency) and changing default behavior (for illustrative purposes I changed application.conf to choose the BioNLPProcessor). Further changes may be needed to mitigate any unintended consequences of these.